### PR TITLE
feat: improve init wizard with model selection and fix Gemini OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ API key lookup order (first match wins):
 | codex | `CODEX_API_KEY` | `keys.codex` |
 | gemini | `GEMINI_API_KEY` | `keys.gemini` |
 
-**OAuth**: Codex and Gemini support OAuth login. Run `automission init` and choose `oauth` when prompted — the CLI will execute `codex login` or `gemini login` and mount the token directory into Docker containers automatically.
+**OAuth**: Codex and Gemini support OAuth login. Run `automission init` and choose `oauth` when prompted — the CLI will trigger the OAuth flow for the selected backend and mount the token directory into Docker containers automatically.
 
 ## Key Design Decisions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.12"
 dependencies = [
     "click>=8.1",
     "jsonschema>=4.0",
+    "questionary>=2.0",
 ]
 authors = [{name = "Codance AI", email = "codance.ai@gmail.com"}]
 keywords = ["agents", "autonomous", "multi-agent", "orchestration", "docker", "llm", "claude", "codex", "gemini"]

--- a/src/automission/cli.py
+++ b/src/automission/cli.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Callable
 
 import click
+import questionary
 
 if TYPE_CHECKING:
     from automission.backend.protocol import AgentBackend
@@ -97,21 +98,27 @@ def init(force: bool) -> None:
 
     # ── Step 1: Agent backend ──
     click.echo("Step 1: Agent backend")
-    agent_backend = click.prompt(
-        "  Choose agent backend",
-        type=click.Choice(backends, case_sensitive=False),
+    agent_backend = questionary.select(
+        "  Choose agent backend:",
+        choices=backends,
         default="claude",
-    )
+    ).ask()
+    if agent_backend is None:
+        raise SystemExit(0)
+    agent_model = _prompt_model(agent_backend)
     agent_auth = _prompt_auth(agent_backend)
 
     # ── Step 2: Planner backend ──
     click.echo()
     click.echo("Step 2: Planner backend")
-    planner_backend = click.prompt(
-        "  Choose planner backend",
-        type=click.Choice(backends, case_sensitive=False),
+    planner_backend = questionary.select(
+        "  Choose planner backend:",
+        choices=backends,
         default="claude",
-    )
+    ).ask()
+    if planner_backend is None:
+        raise SystemExit(0)
+    planner_model = _prompt_model(planner_backend)
     planner_auth = _prompt_auth(planner_backend)
 
     # ── Step 3: Write config ──
@@ -121,8 +128,10 @@ def init(force: bool) -> None:
         CONFIG_PATH,
         agent_backend=agent_backend,
         agent_auth=agent_auth,
+        agent_model=agent_model,
         planner_backend=planner_backend,
         planner_auth=planner_auth,
+        planner_model=planner_model,
     )
     action = "Overwrote" if force and already_existed else "Created"
     click.echo(f"{action} config: {CONFIG_PATH} (mode 600)")
@@ -176,6 +185,28 @@ def init(force: bool) -> None:
                 click.echo("  Skipped image pull.")
 
 
+def _prompt_model(backend: str) -> str:
+    """Prompt user to choose a model for the given backend."""
+    from automission.config import RECOMMENDED_MODELS
+
+    models = RECOMMENDED_MODELS.get(backend, [])
+    if not models:
+        return ""
+    choices = models + ["Other (type manually)"]
+    model = questionary.select(
+        f"  Model for {backend}:",
+        choices=choices,
+        default=models[0],
+    ).ask()
+    if model is None:
+        raise SystemExit(0)
+    if model == "Other (type manually)":
+        model = questionary.text("  Enter model name:").ask()
+        if not model:
+            raise SystemExit(0)
+    return model
+
+
 def _prompt_auth(backend: str) -> str:
     """Prompt for authentication method. Runs OAuth login if chosen.
 
@@ -184,11 +215,13 @@ def _prompt_auth(backend: str) -> str:
     if backend == "claude":
         return "api_key"
 
-    auth = click.prompt(
-        f"  Authentication for {backend}",
-        type=click.Choice(["api_key", "oauth"], case_sensitive=False),
+    auth = questionary.select(
+        f"  Authentication for {backend}:",
+        choices=["api_key", "oauth"],
         default="api_key",
-    )
+    ).ask()
+    if auth is None:
+        raise SystemExit(0)
     if auth == "oauth":
         _run_oauth_login(backend)
     return auth
@@ -203,7 +236,9 @@ def _run_oauth_login(backend: str) -> None:
         return
     click.echo(f"  Running: {' '.join(login_cmd)}")
     try:
-        login_result = subprocess.run(login_cmd, timeout=120)
+        login_result = subprocess.run(
+            login_cmd, timeout=120, stdout=subprocess.DEVNULL
+        )
         if login_result.returncode == 0:
             click.secho(f"  {backend} OAuth: logged in", fg="green")
         else:

--- a/src/automission/config.py
+++ b/src/automission/config.py
@@ -22,14 +22,50 @@ _KEY_MAP: dict[str, tuple[str, str]] = {
     "gemini": ("GEMINI_API_KEY", "gemini"),
 }
 
-DEFAULT_CONFIG_TOML = """\
+# Recommended models per backend (first entry is the default).
+RECOMMENDED_MODELS: dict[str, list[str]] = {
+    "claude": [
+        "claude-sonnet-4-6",
+        "claude-opus-4-6",
+        "claude-haiku-4-5",
+    ],
+    "codex": [
+        "gpt-5.4",
+        "gpt-5.4-pro",
+        "gpt-5.4-mini",
+        "gpt-5.4-nano",
+        "gpt-5.2",
+    ],
+    "gemini": [
+        "gemini-3.1-pro-preview",
+        "gemini-3-flash-preview",
+        "gemini-3.1-flash-lite-preview",
+    ],
+}
+
+
+def default_model(backend: str) -> str:
+    """Return the default model for a backend."""
+    return RECOMMENDED_MODELS.get(backend, [""])[0]
+
+
+def _build_default_config(
+    agent_backend: str = "claude",
+    agent_model: str = "",
+    planner_backend: str = "claude",
+    planner_model: str = "",
+) -> str:
+    """Build the default config TOML with the correct models for chosen backends."""
+    am = agent_model or default_model(agent_backend)
+    pm = planner_model or default_model(planner_backend)
+    return f"""\
 # automission configuration
 # Docs: https://github.com/codance-ai/automission
 
 [defaults]
 agents = 2
-backend = "claude"
-model = "claude-sonnet-4-6"
+backend = "{agent_backend}"
+model = "{am}"
 max_cost = 10.0
 timeout = 3600
 auth = "api_key"              # "api_key" or "oauth"
@@ -42,16 +78,20 @@ auth = "api_key"              # "api_key" or "oauth"
 
 [planner]
 enabled = true
-backend = "claude"
-model = "claude-sonnet-4-6"
+backend = "{planner_backend}"
+model = "{pm}"
 auth = "api_key"
 
 [verifier]
-model = "claude-sonnet-4-6"
+model = "{am}"
 
 [docker]
 image = "ghcr.io/codance-ai/automission:latest"
 """
+
+
+# Keep a static fallback for code that references DEFAULT_CONFIG_TOML directly.
+DEFAULT_CONFIG_TOML = _build_default_config()
 
 
 @dataclass
@@ -157,7 +197,7 @@ _OAUTH_TOKEN_PATHS: dict[str, tuple[str, str]] = {
 # Mapping: backend → login command
 _OAUTH_LOGIN_CMDS: dict[str, list[str]] = {
     "codex": ["codex", "login"],
-    "gemini": ["gemini", "login"],
+    "gemini": ["gemini", "-p", "hello", "--output-format", "json"],
 }
 
 
@@ -216,8 +256,10 @@ def generate_default_config(
     *,
     agent_backend: str = "claude",
     agent_auth: str = "api_key",
+    agent_model: str = "",
     planner_backend: str = "claude",
     planner_auth: str = "api_key",
+    planner_model: str = "",
 ) -> Path:
     """Generate config.toml with secure permissions.
 
@@ -226,10 +268,14 @@ def generate_default_config(
     path = path or CONFIG_PATH
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    data = tomllib.loads(DEFAULT_CONFIG_TOML)
-    data["defaults"]["backend"] = agent_backend
+    cfg_toml = _build_default_config(
+        agent_backend=agent_backend,
+        agent_model=agent_model,
+        planner_backend=planner_backend,
+        planner_model=planner_model,
+    )
+    data = tomllib.loads(cfg_toml)
     data["defaults"]["auth"] = agent_auth
-    data["planner"]["backend"] = planner_backend
     data["planner"]["auth"] = planner_auth
 
     lines = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -393,33 +393,46 @@ class TestNewFlags:
 class TestInitInteractiveFlow:
     """Interactive init flow: choose backends, auth, write config, pull Docker."""
 
+    @staticmethod
+    def _mock_select(answers: list[str]):
+        """Return a patch that makes questionary.select return *answers* in order."""
+        it = iter(answers)
+
+        def fake_select(*args, **kwargs):
+            mock_question = MagicMock()
+            mock_question.ask.return_value = next(it)
+            return mock_question
+
+        return patch("automission.cli.questionary.select", side_effect=fake_select)
+
     def test_claude_defaults_no_auth_prompt(self, runner, tmp_path):
         """Choosing claude for both backends skips auth prompts entirely."""
         config_path = tmp_path / "config.toml"
-        # Input: agent=claude (default), planner=claude (default)
+        # Flow: backend → model → (auth skipped for claude) × 2
         with (
             patch("automission.cli.CONFIG_PATH", config_path),
             patch("subprocess.run") as mock_run,
+            self._mock_select(["claude", "claude-sonnet-4-6", "claude", "claude-sonnet-4-6"]),
         ):
             mock_run.side_effect = FileNotFoundError()  # docker not available
-            result = runner.invoke(cli, ["init"], input="claude\nclaude\n")
+            result = runner.invoke(cli, ["init"])
         assert result.exit_code == 0
-        assert "authentication" not in result.output.lower()
         assert config_path.exists()
 
     def test_codex_agent_oauth_runs_login(self, runner, tmp_path):
         """Selecting codex + oauth triggers 'codex login'."""
         config_path = tmp_path / "config.toml"
-        # Input: agent=codex, auth=oauth, planner=claude (default)
+        # Flow: backend=codex → model → auth=oauth, backend=claude → model
         with (
             patch("automission.cli.CONFIG_PATH", config_path),
             patch("subprocess.run") as mock_run,
+            self._mock_select(["codex", "gpt-5.4", "oauth", "claude", "claude-sonnet-4-6"]),
         ):
             mock_run.side_effect = [
                 MagicMock(returncode=0),  # codex login
                 FileNotFoundError(),  # docker version
             ]
-            result = runner.invoke(cli, ["init"], input="codex\noauth\nclaude\n")
+            result = runner.invoke(cli, ["init"])
         assert result.exit_code == 0
         assert "logged in" in result.output.lower()
 
@@ -429,25 +442,27 @@ class TestInitInteractiveFlow:
         with (
             patch("automission.cli.CONFIG_PATH", config_path),
             patch("subprocess.run") as mock_run,
+            self._mock_select(["codex", "gpt-5.4", "api_key", "claude", "claude-sonnet-4-6"]),
         ):
             mock_run.side_effect = FileNotFoundError()  # docker not available
-            result = runner.invoke(cli, ["init"], input="codex\napi_key\nclaude\n")
+            result = runner.invoke(cli, ["init"])
         assert result.exit_code == 0
         assert "logged in" not in result.output.lower()
 
     def test_gemini_planner_oauth(self, runner, tmp_path):
-        """Selecting gemini as planner + oauth triggers 'gemini login'."""
+        """Selecting gemini as planner + oauth triggers gemini OAuth flow."""
         config_path = tmp_path / "config.toml"
-        # Input: agent=claude, planner=gemini, auth=oauth
+        # Flow: backend=claude → model, backend=gemini → model → auth=oauth
         with (
             patch("automission.cli.CONFIG_PATH", config_path),
             patch("subprocess.run") as mock_run,
+            self._mock_select(["claude", "claude-sonnet-4-6", "gemini", "gemini-3.1-pro-preview", "oauth"]),
         ):
             mock_run.side_effect = [
-                MagicMock(returncode=0),  # gemini login
+                MagicMock(returncode=0),  # gemini oauth
                 FileNotFoundError(),  # docker version
             ]
-            result = runner.invoke(cli, ["init"], input="claude\ngemini\noauth\n")
+            result = runner.invoke(cli, ["init"])
         assert result.exit_code == 0
         assert "gemini" in result.output.lower()
 
@@ -457,30 +472,32 @@ class TestInitInteractiveFlow:
         with (
             patch("automission.cli.CONFIG_PATH", config_path),
             patch("subprocess.run") as mock_run,
+            self._mock_select(["codex", "gpt-5.4", "oauth", "claude", "claude-sonnet-4-6"]),
         ):
             mock_run.side_effect = FileNotFoundError()
-            result = runner.invoke(cli, ["init"], input="codex\noauth\nclaude\n")
+            result = runner.invoke(cli, ["init"])
         assert result.exit_code == 0
         assert "not found" in result.output.lower()
 
     def test_config_reflects_choices(self, runner, tmp_path):
-        """Generated config.toml should reflect the user's backend/auth choices."""
+        """Generated config.toml should reflect the user's backend/auth/model choices."""
         config_path = tmp_path / "config.toml"
         with (
             patch("automission.cli.CONFIG_PATH", config_path),
             patch("subprocess.run") as mock_run,
+            self._mock_select(["codex", "gpt-5.4-mini", "api_key", "gemini", "gemini-3-flash-preview", "api_key"]),
         ):
             mock_run.side_effect = FileNotFoundError()
-            result = runner.invoke(
-                cli, ["init"], input="codex\napi_key\ngemini\napi_key\n"
-            )
+            result = runner.invoke(cli, ["init"])
         assert result.exit_code == 0
         import tomllib
 
         data = tomllib.loads(config_path.read_text())
         assert data["defaults"]["backend"] == "codex"
+        assert data["defaults"]["model"] == "gpt-5.4-mini"
         assert data["defaults"]["auth"] == "api_key"
         assert data["planner"]["backend"] == "gemini"
+        assert data["planner"]["model"] == "gemini-3-flash-preview"
         assert data["planner"]["auth"] == "api_key"
 
 
@@ -745,17 +762,29 @@ class TestEnsureDockerBeforePlanner:
 
 
 class TestInitCommand:
-    # Default input: accept claude defaults for both backends
-    _DEFAULT_INPUT = "claude\nclaude\n"
+    @staticmethod
+    def _mock_select(answers: list[str]):
+        """Return a patch that makes questionary.select return *answers* in order."""
+        it = iter(answers)
+
+        def fake_select(*args, **kwargs):
+            mock_question = MagicMock()
+            mock_question.ask.return_value = next(it)
+            return mock_question
+
+        return patch("automission.cli.questionary.select", side_effect=fake_select)
+
+    _DEFAULT_ANSWERS = ["claude", "claude-sonnet-4-6", "claude", "claude-sonnet-4-6"]
 
     def test_init_creates_config(self, runner, tmp_path):
         config_path = tmp_path / "config.toml"
         with (
             patch("automission.cli.CONFIG_PATH", config_path),
             patch("subprocess.run") as mock_run,
+            self._mock_select(self._DEFAULT_ANSWERS),
         ):
             mock_run.side_effect = FileNotFoundError()  # docker not available
-            result = runner.invoke(cli, ["init"], input=self._DEFAULT_INPUT)
+            result = runner.invoke(cli, ["init"])
         assert result.exit_code == 0
         assert config_path.exists()
         assert "created config" in result.output.lower()
@@ -774,9 +803,10 @@ class TestInitCommand:
         with (
             patch("automission.cli.CONFIG_PATH", config_path),
             patch("subprocess.run") as mock_run,
+            self._mock_select(self._DEFAULT_ANSWERS),
         ):
             mock_run.side_effect = FileNotFoundError()
-            result = runner.invoke(cli, ["init", "--force"], input=self._DEFAULT_INPUT)
+            result = runner.invoke(cli, ["init", "--force"])
         assert result.exit_code == 0
         assert config_path.exists()
 
@@ -785,9 +815,10 @@ class TestInitCommand:
         with (
             patch("automission.cli.CONFIG_PATH", config_path),
             patch("subprocess.run") as mock_run,
+            self._mock_select(self._DEFAULT_ANSWERS),
         ):
             # Docker available, image exists
             mock_run.return_value = MagicMock(returncode=0)
-            result = runner.invoke(cli, ["init"], input=self._DEFAULT_INPUT)
+            result = runner.invoke(cli, ["init"])
         assert result.exit_code == 0
         assert "docker: available" in result.output.lower()


### PR DESCRIPTION
## Summary
- **Fix Gemini OAuth**: `gemini login` is not a valid subcommand — replaced with `gemini -p hello --output-format json` which properly triggers browser-based Google OAuth in non-interactive mode
- **Suppress OAuth noise**: redirect stdout to DEVNULL during OAuth login to hide JSON response output
- **Arrow-key selection**: replace `click.prompt` + `click.Choice` with `questionary.select` for all init prompts (backend, model, auth)
- **Model selection**: add per-backend recommended model lists (`RECOMMENDED_MODELS`) with "Other (type manually)" escape hatch
- **Dynamic config generation**: `generate_default_config` now writes the correct model based on chosen backend instead of hardcoding `claude-sonnet-4-6`

## Test plan
- [x] All 388 tests pass (1 pre-existing flaky SQLite threading test excluded)
- [x] Verified `gemini -p hello` triggers OAuth flow when no creds exist
- [x] Verified stdout suppression hides JSON response during OAuth

🤖 Generated with [Claude Code](https://claude.com/claude-code)