### PR TITLE
feat: make verifier independently configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Interactive setup walks you through:
 
 1. **Agent backend** — choose `claude`, `codex`, or `gemini`, then pick auth method (API key or OAuth)
 2. **Planner backend** — choose independently, then pick auth method
-3. **Docker image** — checks Docker availability and pulls the agent image
+3. **Verifier backend** — defaults to planner settings, or configure separately
+4. **Docker image** — checks Docker availability and pulls the agent image
 
 This creates `~/.automission/config.toml`:
 
@@ -48,6 +49,10 @@ backend = "claude"
 model = "claude-sonnet-4-6"
 
 [planner]
+backend = "claude"
+model = "claude-sonnet-4-6"
+
+[verifier]
 backend = "claude"
 model = "claude-sonnet-4-6"
 

--- a/src/automission/cli.py
+++ b/src/automission/cli.py
@@ -121,7 +121,33 @@ def init(force: bool) -> None:
     planner_model = _prompt_model(planner_backend)
     planner_auth = _prompt_auth(planner_backend)
 
-    # ── Step 3: Write config ──
+    # ── Step 3: Verifier ──
+    click.echo()
+    click.echo("Step 3: Verifier")
+    use_planner = questionary.select(
+        f"  Use same settings as planner ({planner_backend} / {planner_model})?",
+        choices=["yes", "no"],
+        default="yes",
+    ).ask()
+    if use_planner is None:
+        raise SystemExit(0)
+
+    if use_planner == "yes":
+        verifier_backend = planner_backend
+        verifier_model = planner_model
+        verifier_auth = planner_auth
+    else:
+        verifier_backend = questionary.select(
+            "  Choose verifier backend:",
+            choices=backends,
+            default=planner_backend,
+        ).ask()
+        if verifier_backend is None:
+            raise SystemExit(0)
+        verifier_model = _prompt_model(verifier_backend)
+        verifier_auth = _prompt_auth(verifier_backend)
+
+    # ── Step 4: Write config ──
     click.echo()
     already_existed = CONFIG_PATH.exists()
     generate_default_config(
@@ -132,6 +158,9 @@ def init(force: bool) -> None:
         planner_backend=planner_backend,
         planner_auth=planner_auth,
         planner_model=planner_model,
+        verifier_backend=verifier_backend,
+        verifier_auth=verifier_auth,
+        verifier_model=verifier_model,
     )
     action = "Overwrote" if force and already_existed else "Created"
     click.echo(f"{action} config: {CONFIG_PATH} (mode 600)")
@@ -139,9 +168,9 @@ def init(force: bool) -> None:
         "Set API keys there or via environment variables (ANTHROPIC_API_KEY, etc.)"
     )
 
-    # ── Step 4: Docker image ──
+    # ── Step 5: Docker image ──
     click.echo()
-    click.echo("Step 4: Docker image")
+    click.echo("Step 5: Docker image")
     docker_ok = False
     try:
         subprocess.run(
@@ -298,6 +327,17 @@ def _run_oauth_login(backend: str) -> None:
     type=click.Choice(["claude", "codex", "gemini"]),
     help="Backend for Planner/Critic structured output (default: claude)",
 )
+@click.option(
+    "--verifier-model",
+    default=None,
+    help="Model for Verifier (default: follows planner)",
+)
+@click.option(
+    "--verifier-backend",
+    default=None,
+    type=click.Choice(["claude", "codex", "gemini"]),
+    help="Backend for Verifier (default: follows planner)",
+)
 @click.option("--api-key", default=None, help="API key (overrides env var and config)")
 @click.option("--json", "json_output", is_flag=True, help="Output result as JSON")
 @click.option("--detach", is_flag=True, help="Start mission and return immediately")
@@ -320,6 +360,8 @@ def run(
     no_planner: bool,
     planner_model: str,
     planner_backend: str,
+    verifier_model: str | None,
+    verifier_backend: str | None,
     api_key: str | None,
     json_output: bool,
     detach: bool,
@@ -354,6 +396,13 @@ def run(
     agent_auth = resolve_auth_method(backend, cfg, section="defaults")
     planner_auth = resolve_auth_method(planner_backend, cfg, section="planner")
 
+    # Resolve verifier: CLI flag > config [verifier] > planner
+    if verifier_backend is None:
+        verifier_backend = cfg.get("verifier", "backend", planner_backend)
+    if verifier_model is None:
+        verifier_model = cfg.get("verifier", "model", planner_model)
+    verifier_auth = resolve_auth_method(verifier_backend, cfg, section="verifier")
+
     # ── Resolve API key: CLI flag > env var > config ──
     resolved_key = resolve_api_key(backend, api_key, cfg)
     if resolved_key:
@@ -369,6 +418,18 @@ def run(
             env_var = _KEY_MAP.get(planner_backend, ("", ""))[0]
             if env_var and not os.environ.get(env_var):
                 os.environ[env_var] = planner_key
+
+    # Also resolve verifier backend API key if different from both
+    if (
+        verifier_backend != backend
+        and verifier_backend != planner_backend
+        and verifier_auth == "api_key"
+    ):
+        verifier_key = resolve_api_key(verifier_backend, config=cfg)
+        if verifier_key:
+            env_var = _KEY_MAP.get(verifier_backend, ("", ""))[0]
+            if env_var and not os.environ.get(env_var):
+                os.environ[env_var] = verifier_key
 
     # Validate mutually exclusive --goal / --goal-file
     if goal and goal_file:
@@ -457,6 +518,9 @@ def run(
         workspace_dir=Path(workdir) if workdir else None,
         planner_backend_name=planner_backend,
         agent_auth=agent_auth,
+        verifier_backend_name=verifier_backend,
+        verifier_model=verifier_model,
+        verifier_auth=verifier_auth,
     )
 
     from automission.daemon import spawn_executor
@@ -606,225 +670,6 @@ def _edit_plan_draft(draft):
                 return draft
 
 
-def _run_mission(
-    goal: str,
-    acceptance_path: Path | None,
-    verify_path: Path | None,
-    skill_sources: list[str],
-    agents: int,
-    max_iterations: int,
-    max_cost: float,
-    timeout: int,
-    backend_name: str,
-    model: str = "claude-sonnet-4-6",
-    docker_image: str = "ghcr.io/codance-ai/automission:latest",
-    init_files_dir: Path | None = None,
-    workspace_dir: Path | None = None,
-    acceptance_content: str | None = None,
-    verify_content: str | None = None,
-    mission_content: str | None = None,
-    planner_backend_name: str = "claude",
-    agent_auth: str = "api_key",
-) -> tuple[bool, str, str, Path]:
-    """Create workspace and run loop. Returns (passed, mission_id, outcome, workspace)."""
-    from automission.workspace import create_mission
-    from automission.verifier import Verifier
-    from automission.docker import ensure_docker
-    from automission.structured_output import create_structured_backend
-
-    # Set up signal handler for graceful Ctrl+C
-    cancel_event = threading.Event()
-    _setup_signal_handler(cancel_event)
-
-    # Pre-flight: verify Docker is available
-    try:
-        ensure_docker(docker_image)
-    except (RuntimeError, ValueError) as exc:
-        raise click.ClickException(str(exc))
-
-    # Create backend
-    agent_backend = _create_backend(
-        backend_name, docker_image=docker_image, auth_method=agent_auth, model=model
-    )
-
-    import uuid
-
-    mission_id = uuid.uuid4().hex[:12]
-
-    click.echo(f"Creating mission {mission_id}...")
-
-    ws = create_mission(
-        mission_id=mission_id,
-        goal=goal,
-        acceptance_path=acceptance_path,
-        acceptance_content=acceptance_content,
-        verify_path=verify_path,
-        verify_content=verify_content,
-        mission_content=mission_content,
-        backend=agent_backend,
-        workspace_dir=workspace_dir,
-        skill_sources=skill_sources,
-        init_files_dir=init_files_dir,
-        agents=agents,
-        max_iterations=max_iterations,
-        max_cost=max_cost,
-        timeout=timeout,
-        backend_name=backend_name,
-        docker_image=docker_image,
-        model=model,
-    )
-
-    click.echo(f"Workspace: {ws}")
-
-    # Create verifier with structured output backend for critic
-    so_backend = create_structured_backend(
-        planner_backend_name, docker_image=docker_image
-    )
-    verifier = Verifier(
-        backend=so_backend,
-        docker_image=docker_image,
-    )
-
-    if agents > 1:
-        from automission.orchestrator import run_multi_agent
-
-        outcome = run_multi_agent(
-            mission_id=mission_id,
-            mission_dir=ws,
-            n_agents=agents,
-            backend=agent_backend,
-            verifier=verifier,
-            max_iterations=max_iterations,
-            max_cost=max_cost,
-            timeout=timeout,
-            cancel_flag=cancel_event.is_set,
-        )
-    else:
-        outcome = _run_single_agent_frontier(
-            mission_id=mission_id,
-            ws=ws,
-            backend=agent_backend,
-            verifier=verifier,
-            max_iterations=max_iterations,
-            max_cost=max_cost,
-            timeout=timeout,
-            cancel_flag=cancel_event.is_set,
-        )
-
-    return outcome == MissionOutcome.COMPLETED, mission_id, outcome, ws
-
-
-def _run_single_agent_frontier(
-    mission_id: str,
-    ws: Path,
-    backend: "AgentBackend",
-    verifier: "Verifier",
-    max_iterations: int,
-    max_cost: float,
-    timeout: int,
-    cancel_flag: Callable[[], bool],
-) -> str:
-    """Single-agent frontier loop: work on frontier groups one at a time.
-
-    Computes the frontier, picks the first available group, runs run_loop
-    scoped to that group, then re-computes the frontier. Repeats until
-    all groups are done or a circuit breaker fires.
-    """
-    from automission.loop import run_loop
-
-    failed_groups: set[str] = set()  # Track groups that stalled out
-
-    with Ledger(ws / "mission.db") as ledger:
-        while True:
-            if cancel_flag():
-                ledger.update_mission_status(mission_id, MissionOutcome.CANCELLED)
-                return MissionOutcome.CANCELLED
-
-            # Check resource limits
-            mission = ledger.get_mission(mission_id)
-            if mission is None:
-                return MissionOutcome.FAILED
-            if mission["total_attempts"] >= max_iterations:
-                ledger.update_mission_status(mission_id, MissionOutcome.RESOURCE_LIMIT)
-                return MissionOutcome.RESOURCE_LIMIT
-            if mission["total_cost"] >= max_cost:
-                ledger.update_mission_status(mission_id, MissionOutcome.RESOURCE_LIMIT)
-                return MissionOutcome.RESOURCE_LIMIT
-
-            # Compute frontier (excludes completed and claimed)
-            frontier_dicts = ledger.get_frontier_groups(mission_id)
-            if not frontier_dicts:
-                # No frontier = all groups done or blocked
-                groups = ledger.get_acceptance_groups(mission_id)
-                all_done = bool(groups) and all(
-                    ledger.is_group_completed(g.id) for g in groups
-                )
-                if all_done:
-                    ledger.update_mission_status(mission_id, MissionOutcome.COMPLETED)
-                    return MissionOutcome.COMPLETED
-                # Blocked (shouldn't happen in valid DAG)
-                ledger.update_mission_status(mission_id, MissionOutcome.FAILED)
-                return MissionOutcome.FAILED
-
-            # Get full AcceptanceGroup objects for the frontier, skip failed
-            all_groups = ledger.get_acceptance_groups(mission_id)
-            frontier_ids = {g["id"] for g in frontier_dicts}
-            target_groups = [
-                g
-                for g in all_groups
-                if g.id in frontier_ids and g.id not in failed_groups
-            ]
-
-            if not target_groups:
-                # All frontier groups have failed — mission fails
-                ledger.update_mission_status(mission_id, MissionOutcome.FAILED)
-                return MissionOutcome.FAILED
-
-            # Budget remaining iterations across frontier groups
-            remaining_iters = max_iterations - mission["total_attempts"]
-            per_group_iters = max(1, remaining_iters // len(target_groups))
-
-            logger.info(
-                "Frontier: %s (budget %d iters each)",
-                [g.id for g in target_groups],
-                per_group_iters,
-            )
-
-            # Work on the first available frontier group
-            current_group = target_groups[0]
-            outcome = run_loop(
-                mission_id=mission_id,
-                workdir=ws,
-                backend=backend,
-                verifier=verifier,
-                max_iterations=mission["total_attempts"] + per_group_iters,
-                max_cost=max_cost,
-                timeout=timeout,
-                cancel_flag=cancel_flag,
-                target_groups=[current_group],
-            )
-
-            if outcome == MissionOutcome.COMPLETED:
-                # Check if ALL groups done (target group passed, but others may remain)
-                groups = ledger.get_acceptance_groups(mission_id)
-                all_done = bool(groups) and all(
-                    ledger.is_group_completed(g.id) for g in groups
-                )
-                if all_done:
-                    ledger.update_mission_status(mission_id, MissionOutcome.COMPLETED)
-                    return MissionOutcome.COMPLETED
-                # Target group done, new frontier may have opened — loop
-                continue
-
-            if outcome == MissionOutcome.CANCELLED:
-                return MissionOutcome.CANCELLED
-
-            if outcome == MissionOutcome.RESOURCE_LIMIT:
-                return MissionOutcome.RESOURCE_LIMIT
-
-            # Stall/failure on this group — skip it and try next
-            failed_groups.add(current_group.id)
-            logger.info("Group %s failed, skipping", current_group.id)
 
 
 def _collect_changed_files(ledger: Ledger, mission_id: str, ws: Path) -> list[dict]:
@@ -914,6 +759,9 @@ def _create_mission_workspace(
     mission_content: str | None = None,
     planner_backend_name: str = "claude",
     agent_auth: str = "api_key",
+    verifier_backend_name: str = "claude",
+    verifier_model: str = "claude-sonnet-4-6",
+    verifier_auth: str = "api_key",
 ) -> tuple[str, Path]:
     """Create workspace and return (mission_id, workspace_path). Does NOT start execution."""
     from automission.workspace import create_mission
@@ -952,6 +800,10 @@ def _create_mission_workspace(
         backend_name=backend_name,
         docker_image=docker_image,
         model=model,
+        agent_auth=agent_auth,
+        verifier_backend_name=verifier_backend_name,
+        verifier_model=verifier_model,
+        verifier_auth=verifier_auth,
     )
     return mission_id, ws
 

--- a/src/automission/config.py
+++ b/src/automission/config.py
@@ -54,10 +54,14 @@ def _build_default_config(
     agent_model: str = "",
     planner_backend: str = "claude",
     planner_model: str = "",
+    verifier_backend: str = "",
+    verifier_model: str = "",
 ) -> str:
     """Build the default config TOML with the correct models for chosen backends."""
     am = agent_model or default_model(agent_backend)
     pm = planner_model or default_model(planner_backend)
+    vb = verifier_backend or planner_backend
+    vm = verifier_model or pm
     return f"""\
 # automission configuration
 # Docs: https://github.com/codance-ai/automission
@@ -83,7 +87,9 @@ model = "{pm}"
 auth = "api_key"
 
 [verifier]
-model = "{am}"
+backend = "{vb}"
+model = "{vm}"
+auth = "api_key"
 
 [docker]
 image = "ghcr.io/codance-ai/automission:latest"
@@ -260,6 +266,9 @@ def generate_default_config(
     planner_backend: str = "claude",
     planner_auth: str = "api_key",
     planner_model: str = "",
+    verifier_backend: str = "",
+    verifier_auth: str = "api_key",
+    verifier_model: str = "",
 ) -> Path:
     """Generate config.toml with secure permissions.
 
@@ -273,10 +282,13 @@ def generate_default_config(
         agent_model=agent_model,
         planner_backend=planner_backend,
         planner_model=planner_model,
+        verifier_backend=verifier_backend,
+        verifier_model=verifier_model,
     )
     data = tomllib.loads(cfg_toml)
     data["defaults"]["auth"] = agent_auth
     data["planner"]["auth"] = planner_auth
+    data["verifier"]["auth"] = verifier_auth
 
     lines = [
         "# automission configuration",

--- a/src/automission/db.py
+++ b/src/automission/db.py
@@ -41,6 +41,10 @@ class Ledger:
                 status TEXT NOT NULL DEFAULT 'running',
                 backend TEXT NOT NULL DEFAULT 'claude',
                 model TEXT NOT NULL DEFAULT 'claude-sonnet-4-6',
+                backend_auth TEXT NOT NULL DEFAULT 'api_key',
+                verifier_backend TEXT NOT NULL DEFAULT 'claude',
+                verifier_model TEXT NOT NULL DEFAULT 'claude-sonnet-4-6',
+                verifier_auth TEXT NOT NULL DEFAULT 'api_key',
                 agents INTEGER NOT NULL DEFAULT 1,
                 max_iterations INTEGER NOT NULL DEFAULT 20,
                 max_cost REAL NOT NULL DEFAULT 10.0,
@@ -131,6 +135,10 @@ class Ledger:
         goal: str,
         backend: str = "claude",
         model: str = "claude-sonnet-4-6",
+        backend_auth: str = "api_key",
+        verifier_backend: str = "claude",
+        verifier_model: str = "claude-sonnet-4-6",
+        verifier_auth: str = "api_key",
         agents: int = 1,
         max_iterations: int = 20,
         max_cost: float = 10.0,
@@ -138,13 +146,19 @@ class Ledger:
         docker_image: str = "ghcr.io/codance-ai/automission:latest",
     ) -> None:
         self.conn.execute(
-            """INSERT INTO missions (id, goal, backend, model, agents, max_iterations, max_cost, timeout, docker_image)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            """INSERT INTO missions (id, goal, backend, model, backend_auth,
+               verifier_backend, verifier_model, verifier_auth,
+               agents, max_iterations, max_cost, timeout, docker_image)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 mission_id,
                 goal,
                 backend,
                 model,
+                backend_auth,
+                verifier_backend,
+                verifier_model,
+                verifier_auth,
                 agents,
                 max_iterations,
                 max_cost,

--- a/src/automission/executor.py
+++ b/src/automission/executor.py
@@ -126,6 +126,10 @@ def _execute_mission(
 
     backend_name = mission.get("backend", "claude")
     model = mission.get("model", "claude-sonnet-4-6")
+    backend_auth = mission.get("backend_auth", "api_key")
+    verifier_backend_name = mission.get("verifier_backend", "claude")
+    verifier_model = mission.get("verifier_model", "claude-sonnet-4-6")
+    verifier_auth = mission.get("verifier_auth", "api_key")
     docker_image = mission.get("docker_image", "ghcr.io/codance-ai/automission:latest")
     agents = mission.get("agents", 1)
     max_iterations = mission.get("max_iterations", 20)
@@ -134,14 +138,32 @@ def _execute_mission(
 
     # Create backend
     if backend_name == "claude":
-        agent_backend = ClaudeCodeBackend(docker_image=docker_image, model=model)
+        agent_backend = ClaudeCodeBackend(
+            docker_image=docker_image, model=model, auth_method=backend_auth
+        )
+    elif backend_name == "codex":
+        from automission.backend.codex import CodexBackend
+
+        agent_backend = CodexBackend(
+            docker_image=docker_image, model=model, auth_method=backend_auth
+        )
+    elif backend_name == "gemini":
+        from automission.backend.gemini import GeminiBackend
+
+        agent_backend = GeminiBackend(
+            docker_image=docker_image, model=model, auth_method=backend_auth
+        )
     else:
         logger.error("Unsupported backend: %s", backend_name)
         return MissionOutcome.FAILED
 
     # Create verifier
-    so_backend = create_structured_backend("claude", docker_image=docker_image)
-    verifier = Verifier(backend=so_backend, docker_image=docker_image)
+    so_backend = create_structured_backend(
+        verifier_backend_name, docker_image=docker_image, auth_method=verifier_auth
+    )
+    verifier = Verifier(
+        backend=so_backend, verifier_model=verifier_model, docker_image=docker_image
+    )
 
     # Build combined cancel flag: check cancel_event AND desired_state=="stopping" in DB
     def _combined_cancel() -> bool:

--- a/src/automission/workspace.py
+++ b/src/automission/workspace.py
@@ -36,6 +36,10 @@ def create_mission(
     backend_name: str = "claude",
     docker_image: str = "ghcr.io/codance-ai/automission:latest",
     model: str = "claude-sonnet-4-6",
+    agent_auth: str = "api_key",
+    verifier_backend_name: str = "claude",
+    verifier_model: str = "claude-sonnet-4-6",
+    verifier_auth: str = "api_key",
 ) -> Path:
     """Create and initialize a mission workspace.
 
@@ -106,6 +110,10 @@ def create_mission(
         goal=goal,
         backend=backend_name,
         model=model,
+        backend_auth=agent_auth,
+        verifier_backend=verifier_backend_name,
+        verifier_model=verifier_model,
+        verifier_auth=verifier_auth,
         agents=agents,
         max_iterations=max_iterations,
         max_cost=max_cost,

--- a/tests/test_acceptance_graph.py
+++ b/tests/test_acceptance_graph.py
@@ -361,20 +361,23 @@ class TestSingleAgentFrontierLoop:
             init_files_dir=fixture_dir / "workspace",
         )
 
-        from automission.cli import _run_single_agent_frontier
+        from automission.executor import _run_single_agent_frontier
+        from automission.events import EventWriter
         from automission.verifier import Verifier
 
         verifier = Verifier()
-        outcome = _run_single_agent_frontier(
-            mission_id="dag-001",
-            ws=ws,
-            backend=backend,
-            verifier=verifier,
-            max_iterations=20,
-            max_cost=10.0,
-            timeout=3600,
-            cancel_flag=lambda: False,
-        )
+        with EventWriter(ws / "events.jsonl") as ew:
+            outcome = _run_single_agent_frontier(
+                mission_id="dag-001",
+                ws=ws,
+                backend=backend,
+                verifier=verifier,
+                max_iterations=20,
+                max_cost=10.0,
+                timeout=3600,
+                cancel_flag=lambda: False,
+                event_writer=ew,
+            )
 
         assert outcome == "completed"
 
@@ -410,20 +413,23 @@ class TestSingleAgentFrontierLoop:
             init_files_dir=fixture_dir / "workspace",
         )
 
-        from automission.cli import _run_single_agent_frontier
+        from automission.executor import _run_single_agent_frontier
+        from automission.events import EventWriter
         from automission.verifier import Verifier
 
         verifier = Verifier()
-        _run_single_agent_frontier(
-            mission_id="dag-002",
-            ws=ws,
-            backend=backend,
-            verifier=verifier,
-            max_iterations=20,
-            max_cost=10.0,
-            timeout=3600,
-            cancel_flag=lambda: False,
-        )
+        with EventWriter(ws / "events.jsonl") as ew:
+            _run_single_agent_frontier(
+                mission_id="dag-002",
+                ws=ws,
+                backend=backend,
+                verifier=verifier,
+                max_iterations=20,
+                max_cost=10.0,
+                timeout=3600,
+                cancel_flag=lambda: False,
+                event_writer=ew,
+            )
 
         # The first attempt's prompt should mention "Current Focus"
         # with basic_operations (the first frontier group)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,24 +61,22 @@ class TestRunCommand:
         result = runner.invoke(cli, ["run"])
         assert result.exit_code != 0
 
-    @patch("automission.cli._run_mission")
-    def test_run_with_minimal_args(self, mock_run, runner, fixture_dir):
-        mock_run.return_value = (True, "test-001", "completed", Path("/tmp/fake-ws"))
-        runner.invoke(
-            cli,
-            [
-                "run",
-                "--goal",
-                "Build calculator",
-                "--acceptance",
-                str(fixture_dir / "ACCEPTANCE.md"),
-                "--verify",
-                str(fixture_dir / "verify.sh"),
-            ],
-        )
-        # _run_mission is kept intact but run command no longer calls it directly
-        # Test the daemon path instead
-        assert True  # _run_mission is tested separately
+    def test_run_with_minimal_args(self, runner, fixture_dir):
+        mocks = _mock_daemon_run()
+        with mocks[0], mocks[1], mocks[2], mocks[3], mocks[4]:
+            result = runner.invoke(
+                cli,
+                [
+                    "run",
+                    "--goal",
+                    "Build calculator",
+                    "--acceptance",
+                    str(fixture_dir / "ACCEPTANCE.md"),
+                    "--verify",
+                    str(fixture_dir / "verify.sh"),
+                ],
+            )
+            assert result.exit_code == 0
 
     def test_run_with_minimal_args_daemon(self, runner, fixture_dir):
         mocks = _mock_daemon_run()
@@ -124,11 +122,32 @@ class TestRunCommand:
             )
             assert result.exit_code == 0
 
-    @patch("automission.cli._run_mission")
-    def test_run_with_all_flags(self, mock_run, runner, fixture_dir):
-        mock_run.return_value = (True, "test-001", "completed", Path("/tmp/fake-ws"))
-        # _run_mission still exists but run command uses daemon path
-        assert True
+    def test_run_with_all_flags(self, runner, fixture_dir):
+        mocks = _mock_daemon_run()
+        with mocks[0], mocks[1], mocks[2], mocks[3], mocks[4]:
+            result = runner.invoke(
+                cli,
+                [
+                    "run",
+                    "--goal",
+                    "Build calculator",
+                    "--acceptance",
+                    str(fixture_dir / "ACCEPTANCE.md"),
+                    "--verify",
+                    str(fixture_dir / "verify.sh"),
+                    "--agents",
+                    "1",
+                    "--max-iterations",
+                    "10",
+                    "--max-cost",
+                    "5.0",
+                    "--timeout",
+                    "1800",
+                    "--backend",
+                    "claude",
+                ],
+            )
+            assert result.exit_code == 0
 
 
 class TestRunModelFlag:
@@ -397,12 +416,12 @@ class TestInitInteractiveFlow:
     def test_claude_defaults_no_auth_prompt(self, runner, tmp_path):
         """Choosing claude for both backends skips auth prompts entirely."""
         config_path = tmp_path / "config.toml"
-        # Flow: backend → model → (auth skipped for claude) × 2
+        # Flow: agent backend → model → planner backend → model → verifier "yes"
         with (
             patch("automission.cli.CONFIG_PATH", config_path),
             patch("subprocess.run") as mock_run,
             mock_questionary_select(
-                ["claude", "claude-sonnet-4-6", "claude", "claude-sonnet-4-6"]
+                ["claude", "claude-sonnet-4-6", "claude", "claude-sonnet-4-6", "yes"]
             ),
         ):
             mock_run.side_effect = FileNotFoundError()  # docker not available
@@ -413,12 +432,12 @@ class TestInitInteractiveFlow:
     def test_codex_agent_oauth_runs_login(self, runner, tmp_path):
         """Selecting codex + oauth triggers 'codex login'."""
         config_path = tmp_path / "config.toml"
-        # Flow: backend=codex → model → auth=oauth, backend=claude → model
+        # Flow: backend=codex → model → auth=oauth, backend=claude → model, verifier "yes"
         with (
             patch("automission.cli.CONFIG_PATH", config_path),
             patch("subprocess.run") as mock_run,
             mock_questionary_select(
-                ["codex", "gpt-5.4", "oauth", "claude", "claude-sonnet-4-6"]
+                ["codex", "gpt-5.4", "oauth", "claude", "claude-sonnet-4-6", "yes"]
             ),
         ):
             mock_run.side_effect = [
@@ -436,7 +455,7 @@ class TestInitInteractiveFlow:
             patch("automission.cli.CONFIG_PATH", config_path),
             patch("subprocess.run") as mock_run,
             mock_questionary_select(
-                ["codex", "gpt-5.4", "api_key", "claude", "claude-sonnet-4-6"]
+                ["codex", "gpt-5.4", "api_key", "claude", "claude-sonnet-4-6", "yes"]
             ),
         ):
             mock_run.side_effect = FileNotFoundError()  # docker not available
@@ -447,7 +466,7 @@ class TestInitInteractiveFlow:
     def test_gemini_planner_oauth(self, runner, tmp_path):
         """Selecting gemini as planner + oauth triggers gemini OAuth flow."""
         config_path = tmp_path / "config.toml"
-        # Flow: backend=claude → model, backend=gemini → model → auth=oauth
+        # Flow: backend=claude → model, backend=gemini → model → auth=oauth, verifier "yes"
         with (
             patch("automission.cli.CONFIG_PATH", config_path),
             patch("subprocess.run") as mock_run,
@@ -458,6 +477,7 @@ class TestInitInteractiveFlow:
                     "gemini",
                     "gemini-3.1-pro-preview",
                     "oauth",
+                    "yes",
                 ]
             ),
         ):
@@ -476,7 +496,7 @@ class TestInitInteractiveFlow:
             patch("automission.cli.CONFIG_PATH", config_path),
             patch("subprocess.run") as mock_run,
             mock_questionary_select(
-                ["codex", "gpt-5.4", "oauth", "claude", "claude-sonnet-4-6"]
+                ["codex", "gpt-5.4", "oauth", "claude", "claude-sonnet-4-6", "yes"]
             ),
         ):
             mock_run.side_effect = FileNotFoundError()
@@ -498,6 +518,7 @@ class TestInitInteractiveFlow:
                     "gemini",
                     "gemini-3-flash-preview",
                     "api_key",
+                    "yes",  # verifier: same as planner
                 ]
             ),
         ):
@@ -513,6 +534,39 @@ class TestInitInteractiveFlow:
         assert data["planner"]["backend"] == "gemini"
         assert data["planner"]["model"] == "gemini-3-flash-preview"
         assert data["planner"]["auth"] == "api_key"
+        # Verifier should match planner when "yes" is selected
+        assert data["verifier"]["backend"] == "gemini"
+        assert data["verifier"]["model"] == "gemini-3-flash-preview"
+        assert data["verifier"]["auth"] == "api_key"
+
+    def test_config_verifier_independent(self, runner, tmp_path):
+        """When user says 'no', verifier gets its own backend/model/auth."""
+        config_path = tmp_path / "config.toml"
+        with (
+            patch("automission.cli.CONFIG_PATH", config_path),
+            patch("subprocess.run") as mock_run,
+            mock_questionary_select(
+                [
+                    "claude",
+                    "claude-sonnet-4-6",  # agent
+                    "claude",
+                    "claude-sonnet-4-6",  # planner
+                    "no",  # verifier: configure separately
+                    "gemini",
+                    "gemini-3-flash-preview",
+                    "api_key",  # verifier config
+                ]
+            ),
+        ):
+            mock_run.side_effect = FileNotFoundError()
+            result = runner.invoke(cli, ["init"])
+        assert result.exit_code == 0
+        import tomllib
+
+        data = tomllib.loads(config_path.read_text())
+        assert data["verifier"]["backend"] == "gemini"
+        assert data["verifier"]["model"] == "gemini-3-flash-preview"
+        assert data["verifier"]["auth"] == "api_key"
 
     def test_custom_model_via_other(self, runner, tmp_path):
         """Selecting 'Other (type manually)' allows entering a custom model name."""
@@ -526,6 +580,7 @@ class TestInitInteractiveFlow:
                     "Other (type manually)",
                     "claude",
                     "claude-sonnet-4-6",
+                    "yes",
                 ]
             ),
             patch("automission.cli.questionary.text") as mock_text,
@@ -804,7 +859,7 @@ class TestEnsureDockerBeforePlanner:
 
 
 class TestInitCommand:
-    _DEFAULT_ANSWERS = ["claude", "claude-sonnet-4-6", "claude", "claude-sonnet-4-6"]
+    _DEFAULT_ANSWERS = ["claude", "claude-sonnet-4-6", "claude", "claude-sonnet-4-6", "yes"]
 
     def test_init_creates_config(self, runner, tmp_path):
         config_path = tmp_path / "config.toml"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -186,6 +186,7 @@ class TestGenerateDefaultConfig:
         assert "defaults" in data
         assert "keys" in data
         assert "planner" in data
+        assert "verifier" in data
         assert "docker" in data
 
     def test_default_values(self, config_dir):
@@ -203,6 +204,9 @@ class TestGenerateDefaultConfig:
         assert data["docker"]["image"] == "ghcr.io/codance-ai/automission:latest"
         assert data["planner"]["backend"] == "claude"
         assert data["planner"]["auth"] == "api_key"
+        assert data["verifier"]["backend"] == "claude"
+        assert data["verifier"]["model"] == "claude-sonnet-4-6"
+        assert data["verifier"]["auth"] == "api_key"
 
 
 class TestResolveAuthMethod:


### PR DESCRIPTION
## Summary

- Add Step 3 in init wizard for Verifier configuration — defaults to planner settings, with option to configure independently
- Add `--verifier-backend` and `--verifier-model` CLI flags to `automission run`
- Add `verifier_backend`/`verifier_model`/`verifier_auth` columns to missions DB schema, frozen at mission creation time
- Executor reads verifier config from mission DB, supports all backends (claude/codex/gemini)
- Remove unused `_run_mission()` and `_run_single_agent_frontier()` dead code from cli.py

## Test plan

- [x] All tests pass (390 passed, 15 skipped)
- [x] Init wizard verifier defaults to planner path tested
- [x] Init wizard verifier independent config path tested
- [x] Config generation includes verifier section verified
- [x] `_run_single_agent_frontier` migrated to executor, acceptance graph tests pass

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)