### PR TITLE
fix: complete non-root user migration and add multi-arch Docker build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -46,6 +48,7 @@ jobs:
       - uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,9 @@ RUN npm install -g @openai/codex
 # Install Gemini CLI
 RUN npm install -g @google/gemini-cli
 
+# Pre-create CLI config dirs so tools don't fail on first write
+RUN mkdir -p $HOME/.gemini $HOME/.codex
+
 # Install pytest (for verify.sh that runs tests)
 RUN pip install --no-cache-dir --user pytest
 

--- a/src/automission/config.py
+++ b/src/automission/config.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from automission.docker import CONTAINER_HOME
+
 logger = logging.getLogger(__name__)
 
 CONFIG_DIR = Path.home() / ".automission"
@@ -196,8 +198,8 @@ def resolve_default(
 
 # Mapping: backend → (host_dir, container_dir) for OAuth token mounts
 _OAUTH_TOKEN_PATHS: dict[str, tuple[str, str]] = {
-    "codex": (str(Path.home() / ".codex"), "/root/.codex"),
-    "gemini": (str(Path.home() / ".gemini"), "/root/.gemini"),
+    "codex": (str(Path.home() / ".codex"), f"{CONTAINER_HOME}/.codex"),
+    "gemini": (str(Path.home() / ".gemini"), f"{CONTAINER_HOME}/.gemini"),
 }
 
 # Mapping: backend → login command

--- a/src/automission/docker.py
+++ b/src/automission/docker.py
@@ -10,6 +10,9 @@ logger = logging.getLogger(__name__)
 
 DOCKER_IMAGE_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_/:\-\.]*$")
 
+# Must match the non-root user created in Dockerfile (USER agent).
+CONTAINER_HOME = "/home/agent"
+
 
 def build_docker_cmd(
     image: str,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -174,7 +174,10 @@ class TestRunModelFlag:
 
     def test_run_default_model(self, runner, fixture_dir):
         mocks = _mock_daemon_run()
-        with mocks[0] as mock_ws, mocks[1], mocks[2], mocks[3], mocks[4]:
+        with mocks[0] as mock_ws, mocks[1], mocks[2], mocks[3], mocks[4], patch(
+            "automission.cli.load_config",
+            return_value=__import__("automission.config", fromlist=["AutomissionConfig"]).AutomissionConfig(),
+        ):
             result = runner.invoke(
                 cli,
                 [

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -419,6 +419,9 @@ class TestMergeLock:
     def test_thread_safety(self, tmp_path):
         """Two threads race for the merge lock; only one should win."""
         db_path = tmp_path / "thread_test.db"
+        # Initialize DB schema before threads to avoid WAL pragma race
+        init_db = Ledger(db_path)
+        init_db.close()
         results = []
 
         def try_acquire(agent_id):


### PR DESCRIPTION
## Summary

- **Root cause**: Dockerfile switched to non-root `agent` user but downstream code still referenced `/root/` paths
- Fix OAuth volume mount paths (`/root/.gemini` → `/home/agent/.gemini`, same for `.codex`) by introducing a `CONTAINER_HOME` constant as single source of truth
- Pre-create `.gemini` and `.codex` directories in Dockerfile to prevent `ENOENT` on first CLI write
- Add multi-arch Docker build (linux/amd64 + linux/arm64) via QEMU + buildx for Apple Silicon support
- Fix two pre-existing flaky tests (`test_run_default_model` config leak, `test_thread_safety` WAL pragma race)

Closes #8

## Test plan

- [x] All 391 tests pass (0 failures, 15 skipped)
- [ ] Verify Docker image builds for both amd64 and arm64 on next release tag
- [ ] Verify `automission run` with Gemini backend no longer fails with ENOENT

🤖 Generated with [Claude Code](https://claude.com/claude-code)