### PR TITLE
fix: populate total_attempts in mission terminal events

### DIFF
--- a/src/automission/cli.py
+++ b/src/automission/cli.py
@@ -898,10 +898,9 @@ def _render_event(event: dict) -> None:
         gid = event.get("group_id", "?")
         click.secho(f"  Group {gid} completed!", fg="green")
     elif etype == "mission_completed":
-        cost = event.get("total_cost", 0)
         attempts = event.get("total_attempts", 0)
         click.secho(
-            f"\nMission completed! (${cost:.2f}, {attempts} attempts)", fg="green"
+            f"\nMission completed! ({attempts} attempts)", fg="green"
         )
     elif etype == "mission_failed":
         outcome = event.get("outcome", "failed")

--- a/src/automission/executor.py
+++ b/src/automission/executor.py
@@ -396,36 +396,65 @@ def run_executor(workspace_dir: Path, mission_id: str) -> None:
             if outcome == MissionOutcome.COMPLETED:
                 with Ledger(workspace_dir / "mission.db") as ledger:
                     ledger.update_mission_status(mission_id, MissionOutcome.COMPLETED)
+                    mission = ledger.get_mission(mission_id)
                 event_writer.emit(
-                    "mission_completed", {"mission_id": mission_id, "outcome": outcome}
+                    "mission_completed",
+                    {
+                        "mission_id": mission_id,
+                        "outcome": outcome,
+                        "total_attempts": mission["total_attempts"] if mission else 0,
+                    },
                 )
             elif outcome == MissionOutcome.FAILED:
                 with Ledger(workspace_dir / "mission.db") as ledger:
                     ledger.update_mission_status(mission_id, MissionOutcome.FAILED)
+                    mission = ledger.get_mission(mission_id)
                 event_writer.emit(
-                    "mission_failed", {"mission_id": mission_id, "outcome": outcome}
+                    "mission_failed",
+                    {
+                        "mission_id": mission_id,
+                        "outcome": outcome,
+                        "total_attempts": mission["total_attempts"] if mission else 0,
+                    },
                 )
             elif outcome == MissionOutcome.CANCELLED:
                 with Ledger(workspace_dir / "mission.db") as ledger:
                     ledger.update_mission_status(mission_id, MissionOutcome.CANCELLED)
+                    mission = ledger.get_mission(mission_id)
                 event_writer.emit(
-                    "mission_failed", {"mission_id": mission_id, "outcome": outcome}
+                    "mission_failed",
+                    {
+                        "mission_id": mission_id,
+                        "outcome": outcome,
+                        "total_attempts": mission["total_attempts"] if mission else 0,
+                    },
                 )
             elif outcome == MissionOutcome.RESOURCE_LIMIT:
                 with Ledger(workspace_dir / "mission.db") as ledger:
                     ledger.update_mission_status(
                         mission_id, MissionOutcome.RESOURCE_LIMIT
                     )
+                    mission = ledger.get_mission(mission_id)
                 event_writer.emit(
-                    "mission_failed", {"mission_id": mission_id, "outcome": outcome}
+                    "mission_failed",
+                    {
+                        "mission_id": mission_id,
+                        "outcome": outcome,
+                        "total_attempts": mission["total_attempts"] if mission else 0,
+                    },
                 )
             else:
                 # Unknown outcome — treat as failure
                 with Ledger(workspace_dir / "mission.db") as ledger:
                     ledger.update_mission_status(mission_id, MissionOutcome.FAILED)
+                    mission = ledger.get_mission(mission_id)
                 event_writer.emit(
                     "mission_failed",
-                    {"mission_id": mission_id, "outcome": str(outcome)},
+                    {
+                        "mission_id": mission_id,
+                        "outcome": str(outcome),
+                        "total_attempts": mission["total_attempts"] if mission else 0,
+                    },
                 )
 
         except Exception as exc:

--- a/tests/test_daemon_integration.py
+++ b/tests/test_daemon_integration.py
@@ -97,14 +97,14 @@ class TestEventLifecycle:
             w.emit("attempt_end", {"status": "completed", "cost_usd": 0.15})
             w.emit("verification", {"passed": True, "score": 0.9})
             w.emit("group_completed", {"group_id": "g1"})
-            w.emit("mission_completed", {"total_cost": 0.5, "total_attempts": 3})
+            w.emit("mission_completed", {"total_attempts": 3})
 
         events = list(EventTailer(events_file).read_existing())
         assert len(events) == 6
         assert events[0]["type"] == "mission_started"
         assert events[0]["mission_id"] == "m-1"
         assert events[5]["type"] == "mission_completed"
-        assert events[5]["total_cost"] == 0.5
+        assert events[5]["total_attempts"] == 3
         # All events should have timestamps
         for e in events:
             assert "ts" in e

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -128,7 +128,7 @@ class TestEventTailer:
         path = tmp_path / "events.jsonl"
         with EventWriter(path) as writer:
             writer.emit("attempt_start", {})
-            writer.emit("mission_completed", {"total_cost": 1.0})
+            writer.emit("mission_completed", {"total_attempts": 1})
             writer.emit("should_not_see", {})
 
         tailer = EventTailer(path)

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -127,6 +127,25 @@ class TestRunExecutor:
 
     def test_writes_events(self, mission_workspace):
         ws = mission_workspace
+        # Record some attempts so total_attempts > 0
+        with Ledger(ws / "mission.db") as ledger:
+            ledger.record_attempt(
+                attempt_id="a-1",
+                mission_id="m-test",
+                agent_id="agent-1",
+                attempt_number=1,
+                status="completed",
+                exit_code=0,
+                duration_s=1.0,
+                cost_usd=0.01,
+                token_input=100,
+                token_output=50,
+                changed_files=[],
+                verification_passed=True,
+                verification_result="{}",
+                commit_hash="abc123",
+            )
+
         with patch("automission.executor._execute_mission") as mock_exec:
             mock_exec.return_value = "completed"
             run_executor(ws, "m-test")
@@ -137,6 +156,9 @@ class TestRunExecutor:
         types = [e["type"] for e in events]
         assert "mission_started" in types
         assert "mission_completed" in types
+        # Verify total_attempts is populated from DB
+        completed_event = [e for e in events if e["type"] == "mission_completed"][0]
+        assert completed_event["total_attempts"] == 1
 
     def test_cleans_pid_on_exit(self, mission_workspace):
         ws = mission_workspace


### PR DESCRIPTION
## Summary

- Fixed `mission_completed` event not including `total_attempts` from DB, causing live view to always show "0 attempts"
- Applied same fix to `mission_failed` events (failed/cancelled/resource_limit) for consistency
- Removed `total_cost` from live view summary display
- Added test asserting `total_attempts` value in emitted event matches DB state

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)