### PR TITLE
feat: implement automission export command

### DIFF
--- a/docs/specs/cli.md
+++ b/docs/specs/cli.md
@@ -45,7 +45,7 @@ When `--backend` is specified, the CLI looks up the corresponding key:
 | `automission stop` | Stop a running mission | **MVP** |
 | `automission list` | List all missions | **MVP** |
 | `automission resume` | Resume a stopped/crashed mission | **MVP** |
-| `automission export` | Export results to a directory | Planned |
+| `automission export` | Export results to a directory | **MVP** |
 | `automission limits` | Adjust runtime constraints | Planned |
 | `automission config` | View/edit global configuration | Planned |
 
@@ -302,15 +302,14 @@ Reads ledger, restarts agent loops from where they left off. Same blocking behav
 
 ---
 
-### `automission export` *(Planned)*
+### `automission export`
 
-Copy mission results to a target directory.
+Copy mission results to a target directory, excluding automission internals (`.git`, `mission.db`, `MISSION.md`, `ACCEPTANCE.md`, `AUTOMISSION.md`, `verify.sh`, `skills/`, `__pycache__`).
 
 ```bash
 automission export abc123 --output ./my-new-project
+automission export abc123 -o ./my-new-project --force  # overwrite existing
 ```
-
-Copies workspace source code (excluding automission internals) to the target directory.
 
 ---
 

--- a/src/automission/cli.py
+++ b/src/automission/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import shutil
 import signal
 import subprocess
 import sys
@@ -1296,6 +1297,68 @@ def list_missions(json_output):
                 f"${cost:.2f}  {m['total_attempts']} attempts  "
                 f"{goal_short}"
             )
+
+
+# ── export command ──
+
+# Internal files that should not be exported
+_EXPORT_EXCLUDE = {
+    ".git",
+    "mission.db",
+    "mission.db-journal",
+    "mission.db-wal",
+    "mission.db-shm",
+    "__pycache__",
+    "MISSION.md",
+    "ACCEPTANCE.md",
+    "AUTOMISSION.md",
+    "verify.sh",
+    "skills",
+}
+
+
+@cli.command()
+@click.argument("mission_id")
+@click.option(
+    "--output",
+    "-o",
+    required=True,
+    type=click.Path(),
+    help="Target directory to export to",
+)
+@click.option("--force", is_flag=True, help="Overwrite existing target directory")
+def export(mission_id: str, output: str, force: bool) -> None:
+    """Export mission workspace to a directory."""
+    ws = _find_mission_workspace(mission_id)
+    if not ws:
+        click.echo(f"Mission {mission_id} not found.")
+        sys.exit(1)
+
+    target = Path(output)
+    if target.exists():
+        if not force:
+            click.echo(
+                f"Target directory already exists: {target}\n"
+                "Use --force to overwrite."
+            )
+            sys.exit(1)
+        shutil.rmtree(target)
+
+    target.mkdir(parents=True, exist_ok=True)
+
+    copied = 0
+    for item in ws.rglob("*"):
+        # Skip excluded top-level entries and their children
+        rel = item.relative_to(ws)
+        if rel.parts[0] in _EXPORT_EXCLUDE:
+            continue
+        if item.is_file():
+            dest = target / rel
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(item, dest)
+            copied += 1
+
+    click.echo(f"Exported {copied} files to {target}")
 
 
 # ── resume command ──

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -916,3 +916,116 @@ class TestInitCommand:
             result = runner.invoke(cli, ["init"])
         assert result.exit_code == 0
         assert "docker: available" in result.output.lower()
+
+
+class TestExportCommand:
+    """Tests for the export command."""
+
+    def _create_fake_workspace(self, tmp_path, mission_id="test-001"):
+        """Create a fake mission workspace with internal and user files."""
+        from automission.db import Ledger
+
+        ws = tmp_path / "missions" / mission_id
+        ws.mkdir(parents=True)
+
+        # User files (should be exported)
+        (ws / "main.py").write_text("print('hello')")
+        (ws / "src").mkdir()
+        (ws / "src" / "app.py").write_text("class App: pass")
+        (ws / "README.md").write_text("# Project")
+
+        # Internal files (should NOT be exported)
+        (ws / ".git").mkdir()
+        (ws / ".git" / "config").write_text("[core]")
+        (ws / "MISSION.md").write_text("# Mission")
+        (ws / "ACCEPTANCE.md").write_text("# Acceptance")
+        (ws / "AUTOMISSION.md").write_text("# Auto")
+        (ws / "verify.sh").write_text("#!/bin/bash")
+        (ws / "skills").mkdir()
+        (ws / "skills" / "skill1.md").write_text("# Skill")
+        (ws / "__pycache__").mkdir()
+        (ws / "__pycache__" / "main.cpython-314.pyc").write_text("bytecode")
+
+        # Create ledger so _find_mission_workspace can find it
+        ledger = Ledger(ws / "mission.db")
+        ledger.create_mission(
+            mission_id=mission_id,
+            goal="test",
+            backend="claude",
+            model="claude-sonnet-4-6",
+            backend_auth="api_key",
+            verifier_backend="claude",
+            verifier_model="claude-sonnet-4-6",
+            verifier_auth="api_key",
+        )
+        ledger.close()
+
+        return ws
+
+    def test_export_copies_user_files_only(self, runner, tmp_path):
+        """Export should copy user files and exclude internal files."""
+        ws = self._create_fake_workspace(tmp_path)
+        output_dir = tmp_path / "exported"
+
+        with patch("automission.cli.DEFAULT_BASE_DIR", tmp_path / "missions"):
+            result = runner.invoke(
+                cli, ["export", "test-001", "--output", str(output_dir)]
+            )
+
+        assert result.exit_code == 0
+        assert "Exported 3 files" in result.output
+
+        # User files present
+        assert (output_dir / "main.py").exists()
+        assert (output_dir / "src" / "app.py").exists()
+        assert (output_dir / "README.md").exists()
+
+        # Internal files absent
+        assert not (output_dir / ".git").exists()
+        assert not (output_dir / "mission.db").exists()
+        assert not (output_dir / "MISSION.md").exists()
+        assert not (output_dir / "ACCEPTANCE.md").exists()
+        assert not (output_dir / "AUTOMISSION.md").exists()
+        assert not (output_dir / "verify.sh").exists()
+        assert not (output_dir / "skills").exists()
+        assert not (output_dir / "__pycache__").exists()
+
+    def test_export_fails_if_target_exists_without_force(self, runner, tmp_path):
+        """Export should refuse to overwrite existing directory."""
+        ws = self._create_fake_workspace(tmp_path)
+        output_dir = tmp_path / "exported"
+        output_dir.mkdir()
+
+        with patch("automission.cli.DEFAULT_BASE_DIR", tmp_path / "missions"):
+            result = runner.invoke(
+                cli, ["export", "test-001", "--output", str(output_dir)]
+            )
+
+        assert result.exit_code != 0
+        assert "--force" in result.output
+
+    def test_export_with_force_overwrites(self, runner, tmp_path):
+        """Export --force should overwrite existing directory."""
+        ws = self._create_fake_workspace(tmp_path)
+        output_dir = tmp_path / "exported"
+        output_dir.mkdir()
+        (output_dir / "old-file.txt").write_text("stale")
+
+        with patch("automission.cli.DEFAULT_BASE_DIR", tmp_path / "missions"):
+            result = runner.invoke(
+                cli, ["export", "test-001", "--output", str(output_dir), "--force"]
+            )
+
+        assert result.exit_code == 0
+        assert (output_dir / "main.py").exists()
+        assert not (output_dir / "old-file.txt").exists()
+
+    def test_export_mission_not_found(self, runner, tmp_path):
+        """Export should fail gracefully for non-existent mission."""
+        with patch("automission.cli.DEFAULT_BASE_DIR", tmp_path / "missions"):
+            result = runner.invoke(
+                cli, ["export", "nonexistent", "--output", str(tmp_path / "out")]
+            )
+
+        assert result.exit_code != 0
+        assert "not found" in result.output


### PR DESCRIPTION
## Summary

- Implements the `automission export <mission_id> --output <path>` command that copies mission workspace files to a target directory
- Excludes automission internals (`.git`, `mission.db`, `MISSION.md`, `ACCEPTANCE.md`, `AUTOMISSION.md`, `verify.sh`, `skills/`, `__pycache__`) from export
- Supports `--force` flag to overwrite existing target directory
- Adds 4 tests covering: normal export, target-exists guard, force overwrite, and mission-not-found error

Closes #15

## Test plan

- [x] All 395 existing tests pass
- [x] 4 new tests for export command pass
- [x] Verified internal files are excluded from export
- [x] Verified `--force` flag overwrites existing directory
- [x] Verified non-existent mission returns error

🤖 Generated with [Claude Code](https://claude.com/claude-code)