### PR TITLE
fix: verifier detects hardcoded Docker paths via randomized mount

### DIFF
--- a/src/automission/backend/protocol.py
+++ b/src/automission/backend/protocol.py
@@ -46,6 +46,11 @@ def format_automission_md(stable: StableContext) -> str:
     )
     lines.append("- Read ACCEPTANCE.md before starting work")
     lines.append("- Run verify.sh after making changes")
+    lines.append(
+        "- Never hardcode /workspace or any absolute path in code or tests. "
+        "Use relative paths (e.g., ./file.py), Path(__file__).parent, or os.getcwd(). "
+        "Your code must be portable and work outside of Docker."
+    )
     for rule in stable.rules:
         lines.append(f"- {rule}")
     lines.append("")

--- a/src/automission/docker.py
+++ b/src/automission/docker.py
@@ -22,18 +22,21 @@ def build_docker_cmd(
     env_pairs: Optional[dict[str, str]] = None,
     volumes: Optional[list[tuple[str, str]]] = None,
     rw_volumes: Optional[list[tuple[str, str]]] = None,
+    container_workdir: str = "/workspace",
 ) -> list[str]:
     """Build a ``docker run --rm`` command list.
 
     Args:
         image: Docker image name. Must match DOCKER_IMAGE_PATTERN.
         inner_cmd: Command to run inside the container.
-        workdir: If provided, mount as ``-v {workdir.resolve()}:/workspace -w /workspace``.
+        workdir: If provided, mount as ``-v {workdir.resolve()}:{container_workdir} -w {container_workdir}``.
         env_keys: Env var names to pass via ``-e NAME``. Docker inherits values from host env.
         env_pairs: Env var key-value pairs to pass via ``-e NAME=VALUE``.
         volumes: List of (host_path, container_path) tuples to mount read-only.
         rw_volumes: List of (host_path, container_path) tuples to mount read-write.
             Used for OAuth token files that need write access for token refresh.
+        container_workdir: Container path to mount workdir at. Defaults to ``/workspace``.
+            The verifier uses a randomized path to detect hardcoded Docker paths.
 
     Returns:
         A list[str] ready for ``subprocess.run()``.
@@ -47,7 +50,7 @@ def build_docker_cmd(
     cmd = ["docker", "run", "--rm"]
 
     if workdir is not None:
-        cmd += ["-v", f"{workdir.resolve()}:/workspace", "-w", "/workspace"]
+        cmd += ["-v", f"{workdir.resolve()}:{container_workdir}", "-w", container_workdir]
 
     for host_path, container_path in volumes or []:
         cmd += ["-v", f"{host_path}:{container_path}:ro"]

--- a/src/automission/verifier.py
+++ b/src/automission/verifier.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import subprocess
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -82,7 +83,13 @@ def run_verify_sh(
     script_path: Path,
     docker_image: str = "ghcr.io/codance-ai/automission:latest",
 ) -> dict[str, Any]:
-    """Run verify.sh and return structured gate result."""
+    """Run verify.sh and return structured gate result.
+
+    Uses a randomized container mount path (instead of /workspace) to detect
+    code that hardcodes Docker-specific paths. If generated tests reference
+    /workspace, they will fail here — catching portability bugs before the
+    mission is marked as passed.
+    """
     try:
         # verify.sh must be inside workspace to mount correctly
         try:
@@ -99,7 +106,17 @@ def run_verify_sh(
                 "stderr": f"verify.sh at {script_path} is outside workspace {workdir}, cannot mount in Docker",
                 "json_output": None,
             }
-        cmd = build_docker_cmd(docker_image, ["bash", str(rel_script)], workdir=workdir)
+        # Randomized mount path to catch hardcoded /workspace references
+        nonce = uuid.uuid4().hex[:8]
+        container_workdir = f"/tmp/_verify_{nonce}"
+        cmd = build_docker_cmd(
+            docker_image,
+            # Configure git safe.directory before running verify.sh so git
+            # operations work at the non-standard mount path.
+            ["bash", "-c", f'git config --global --add safe.directory "{container_workdir}" && bash "{rel_script}"'],
+            workdir=workdir,
+            container_workdir=container_workdir,
+        )
         result = subprocess.run(
             cmd, capture_output=True, text=True, timeout=120, encoding="utf-8"
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,18 +37,21 @@ def _unwrap_docker_in_verifier(monkeypatch):
         ):
             return _real_run(cmd, **kwargs)
         workdir = None
+        container_workdir = None
         i = 2
         inner_cmd = []
+        volumes = []
         while i < len(cmd):
             arg = cmd[i]
             if arg == "--rm":
                 i += 1
             elif arg == "-v" and i + 1 < len(cmd):
-                mount = cmd[i + 1]
-                if ":/workspace" in mount:
-                    workdir = mount.split(":/workspace")[0]
+                volumes.append(cmd[i + 1])
                 i += 2
-            elif arg in ("-w", "-e") and i + 1 < len(cmd):
+            elif arg == "-w" and i + 1 < len(cmd):
+                container_workdir = cmd[i + 1]
+                i += 2
+            elif arg == "-e" and i + 1 < len(cmd):
                 i += 2
             elif arg.startswith("-"):
                 i += 1
@@ -58,6 +61,23 @@ def _unwrap_docker_in_verifier(monkeypatch):
                 break
         else:
             return _real_run(cmd, **kwargs)
+        # Find host path from volume mount matching container_workdir
+        if container_workdir:
+            for vol in volumes:
+                # Format: host_path:container_path[:ro]
+                if f":{container_workdir}" in vol:
+                    workdir = vol.split(f":{container_workdir}")[0]
+                    break
+        # Strip Docker-only setup commands (e.g., git config --global)
+        # from "bash -c 'setup && actual_cmd'" to avoid polluting host env.
+        if (
+            len(inner_cmd) == 3
+            and inner_cmd[0] == "bash"
+            and inner_cmd[1] == "-c"
+            and "&&" in inner_cmd[2]
+        ):
+            actual_cmd = inner_cmd[2].split("&&", 1)[1].strip()
+            inner_cmd = ["bash", "-c", actual_cmd]
         return _real_run(
             inner_cmd,
             cwd=workdir,

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -144,6 +144,23 @@ class TestBuildDockerCmd:
         assert cmd[v_indices[2] + 1] == "/home/user/.codex:/root/.codex"
 
 
+    def test_custom_container_workdir(self, tmp_path):
+        workdir = tmp_path / "project"
+        workdir.mkdir()
+        cmd = build_docker_cmd(
+            "myimage:latest",
+            ["bash", "verify.sh"],
+            workdir=workdir,
+            container_workdir="/tmp/_verify_abc123",
+        )
+        v_idx = cmd.index("-v")
+        assert ":/tmp/_verify_abc123" in cmd[v_idx + 1]
+        w_idx = cmd.index("-w")
+        assert cmd[w_idx + 1] == "/tmp/_verify_abc123"
+        # Default /workspace should not appear
+        assert "/workspace" not in cmd[v_idx + 1]
+
+
 class TestEnsureDocker:
     def test_daemon_not_available(self):
         with patch("automission.docker.subprocess.run") as mock_run:


### PR DESCRIPTION
## Summary

- Verifier now mounts workspace at a randomized container path (`/tmp/_verify_{nonce}`) instead of the fixed `/workspace`, mechanically catching tests that hardcode Docker-specific paths
- Added `container_workdir` parameter to `build_docker_cmd()` for flexible mount paths  
- Added portability rule to AUTOMISSION.md agent instructions as prevention layer
- Updated test fixture to parse Docker mount paths generically

## Root Cause

The agent generates code inside Docker at `/workspace`. The verifier also runs at `/workspace`, so hardcoded paths pass verification but fail on the host. This was the most critical bug — missions completed with PASS but code didn't work outside Docker.

## Fix

**Detection**: Verifier uses randomized mount path → hardcoded `/workspace` references fail naturally  
**Prevention**: Agent instructions now explicitly forbid absolute paths

## Test plan

- [x] All 398 tests pass (15 skipped)
- [x] New test for `container_workdir` parameter
- [x] Conftest Docker unwrap strips setup commands to avoid polluting host gitconfig
- [x] Code review passed (2 issues found and fixed)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>