### PR TITLE
fix: critic schema incompatible with Codex structured output

### DIFF
--- a/src/automission/structured_output/codex.py
+++ b/src/automission/structured_output/codex.py
@@ -25,6 +25,9 @@ def _openai_strict_schema(schema: dict) -> dict:
     1. ``additionalProperties: false`` on every object
     2. ``required`` must list ALL keys in ``properties``
 
+    Raises ``ValueError`` if an object has no ``properties`` (dynamic map) —
+    OpenAI strict mode cannot represent dynamic keys.
+
     Returns a deep copy — the original schema is not mutated.
     """
     schema = dict(schema)
@@ -36,6 +39,12 @@ def _openai_strict_schema(schema: dict) -> dict:
                 k: _openai_strict_schema(v)
                 for k, v in schema["properties"].items()
             }
+        else:
+            raise ValueError(
+                "OpenAI strict mode requires 'properties' on every object. "
+                "Found object without 'properties' (dynamic map). "
+                "Use an array of {key, value} objects instead."
+            )
     if "items" in schema:
         schema["items"] = _openai_strict_schema(schema["items"])
     return schema

--- a/src/automission/verifier.py
+++ b/src/automission/verifier.py
@@ -48,8 +48,16 @@ _CRITIC_TOOL = {
                 },
             },
             "group_statuses": {
-                "type": "object",
-                "description": "Per acceptance group: group_id -> completed (true/false)",
+                "type": "array",
+                "description": "Per acceptance group status.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "group_id": {"type": "string"},
+                        "completed": {"type": "boolean"},
+                    },
+                    "required": ["group_id", "completed"],
+                },
             },
             "suggestion": {
                 "type": "string",
@@ -266,11 +274,23 @@ Evaluate each criterion individually. A group is complete when ALL its required 
 Be specific about what passed and what failed. Provide an actionable suggestion for the next attempt."""
 
         try:
-            return self.backend.query(
+            result = self.backend.query(
                 prompt=prompt,
                 model=self.model,
                 json_schema=_CRITIC_JSON_SCHEMA,
             )
+            # Schema uses array for group_statuses (strict output compat);
+            # convert back to dict[str, bool] for downstream consumers.
+            gs = result.get("group_statuses")
+            if isinstance(gs, list):
+                try:
+                    result["group_statuses"] = {
+                        item["group_id"]: item["completed"] for item in gs
+                    }
+                except (KeyError, TypeError) as e:
+                    logger.warning("Malformed group_statuses from critic: %s", e)
+                    return self._basic_critic(gate["passed"], groups)
+            return result
         except CLIResponseError as e:
             logger.error("Critic CLI call failed: %s", e)
             return self._basic_critic(gate["passed"], groups)

--- a/tests/test_structured_output_codex.py
+++ b/tests/test_structured_output_codex.py
@@ -39,6 +39,52 @@ def _codex_message_event(structured_data: dict) -> dict:
 SIMPLE_SCHEMA = {"type": "object", "properties": {"x": {"type": "string"}}}
 
 
+class TestOpenAIStrictSchema:
+    def test_rejects_object_without_properties(self):
+        """Dynamic map objects (no properties) must raise ValueError."""
+        from automission.structured_output.codex import _openai_strict_schema
+
+        schema = {"type": "object", "description": "dynamic map"}
+        with pytest.raises(ValueError, match="requires 'properties'"):
+            _openai_strict_schema(schema)
+
+    def test_rejects_nested_object_without_properties(self):
+        """Nested dynamic maps inside properties must also raise."""
+        from automission.structured_output.codex import _openai_strict_schema
+
+        schema = {
+            "type": "object",
+            "properties": {
+                "data": {"type": "object", "description": "dynamic"},
+            },
+        }
+        with pytest.raises(ValueError, match="requires 'properties'"):
+            _openai_strict_schema(schema)
+
+    def test_valid_schema_passes(self):
+        from automission.structured_output.codex import _openai_strict_schema
+
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {"id": {"type": "string"}},
+                    },
+                },
+            },
+        }
+        result = _openai_strict_schema(schema)
+        assert result["additionalProperties"] is False
+        assert result["required"] == ["name", "items"]
+        nested = result["properties"]["items"]["items"]
+        assert nested["additionalProperties"] is False
+        assert nested["required"] == ["id"]
+
+
 class TestCodexStructuredOutput:
     def test_successful_query(self):
         backend = CodexStructuredOutput()

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -152,6 +152,62 @@ class TestVerifier:
         assert result.contract_passed is True
         assert result.mission_passed is True
 
+    def test_critic_array_group_statuses_converted_to_dict(
+        self, workspace, sample_groups
+    ):
+        """Critic returns group_statuses as array (strict output format);
+        verifier must convert it to dict[str, bool] for downstream."""
+        script = workspace / "verify.sh"
+        script.write_text("#!/bin/bash\nexit 1\n")
+        script.chmod(0o755)
+
+        critic_output = {
+            "passed_criteria": [],
+            "failed_criteria": [
+                {"criterion": "add works", "passed": False, "detail": "missing"}
+            ],
+            "group_statuses": [
+                {"group_id": "basic", "completed": False},
+            ],
+            "suggestion": "Implement add",
+            "reason": "Not done",
+            "score": 0.3,
+        }
+
+        backend = Mock()
+        backend.query = Mock(return_value=critic_output)
+        verifier = Verifier(backend=backend, verifier_model="claude-sonnet-4-6")
+        result = verifier.evaluate(workspace, script, sample_groups)
+
+        assert result.group_statuses == {"basic": False}
+        assert isinstance(result.group_statuses, dict)
+
+    def test_malformed_group_statuses_falls_back_to_basic(
+        self, workspace, sample_groups
+    ):
+        """Malformed array entries in group_statuses trigger basic_critic fallback."""
+        script = workspace / "verify.sh"
+        script.write_text("#!/bin/bash\nexit 1\n")
+        script.chmod(0o755)
+
+        critic_output = {
+            "passed_criteria": [],
+            "failed_criteria": [],
+            "group_statuses": [{"bad_key": "oops"}],  # missing group_id/completed
+            "suggestion": "",
+            "reason": "",
+            "score": 0.0,
+        }
+
+        backend = Mock()
+        backend.query = Mock(return_value=critic_output)
+        verifier = Verifier(backend=backend, verifier_model="claude-sonnet-4-6")
+        result = verifier.evaluate(workspace, script, sample_groups)
+
+        # Should fall back to basic critic instead of crashing
+        assert result.reason == "Gate verification failed."
+        assert isinstance(result.group_statuses, dict)
+
     def test_critic_cli_failure_falls_back_to_basic(self, workspace, sample_groups):
         script = workspace / "verify.sh"
         script.write_text("#!/bin/bash\nexit 1\n")


### PR DESCRIPTION
## Summary

- **Root cause**: `group_statuses` was a dynamic object (no `properties`) in the critic schema. `_openai_strict_schema()` silently produced an invalid OpenAI strict-mode schema, breaking the entire verification feedback loop for Codex-backed missions.
- **Fix layer 1**: `_openai_strict_schema()` now raises `ValueError` on objects without `properties` — same class of bug (#8) can never silently recur.
- **Fix layer 2**: Changed `group_statuses` from dynamic object to array `[{group_id, completed}]`, with conversion back to `dict[str, bool]` in `_run_critic()` so all downstream code is unaffected.
- Added defensive fallback to `_basic_critic()` if the LLM returns malformed array entries.

## Test plan

- [x] New test: `test_critic_array_group_statuses_converted_to_dict` — verifies array→dict conversion
- [x] New test: `test_malformed_group_statuses_falls_back_to_basic` — verifies graceful fallback
- [x] New test: `TestOpenAIStrictSchema` (3 tests) — verifies ValueError on dynamic objects, nested objects, and valid schemas
- [x] Full suite: 402 passed, 15 skipped

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)