### PR TITLE
feat: show richer execution details in CLI output

### DIFF
--- a/src/automission/cli.py
+++ b/src/automission/cli.py
@@ -879,6 +879,114 @@ def _fmt_tokens(total: int) -> str:
     return f"{total} tokens"
 
 
+def _fmt_changed_files(files: list[str], max_shown: int = 5) -> str:
+    """Format changed files list: 'a.py, b.py (+2 files)'."""
+    if not files:
+        return ""
+    basenames = [Path(f).name for f in files]
+    if len(basenames) <= max_shown:
+        return f"{', '.join(basenames)} ({len(files)} file{'s' if len(files) != 1 else ''})"
+    shown = ", ".join(basenames[:max_shown])
+    return f"{shown} +{len(files) - max_shown} more ({len(files)} files)"
+
+
+def _render_criteria(event_or_vr: dict, *, indent: str = "    ", verbose: bool = False) -> None:
+    """Render per-criterion pass/fail lines.
+
+    Works with both live event dicts and VerifierResult-like dicts.
+    If verbose, shows detail text for each criterion.
+    """
+    failed = event_or_vr.get("failed_criteria", [])
+    passed = event_or_vr.get("passed_criteria", [])
+
+    # Normalize: event format is [{criterion, group}], VR format may be [{criterion, detail}]
+    for c in failed:
+        name = c.get("criterion", c) if isinstance(c, dict) else c
+        group = c.get("group", "") if isinstance(c, dict) else ""
+        detail = c.get("detail", "") if isinstance(c, dict) else ""
+        group_tag = f"[{group}] " if group else ""
+        click.echo(f"{indent}{click.style('✗', fg='red')} {group_tag}{name}")
+        if verbose and detail:
+            click.echo(f"{indent}  → {detail}")
+    for c in passed:
+        name = c.get("criterion", c) if isinstance(c, dict) else c
+        group = c.get("group", "") if isinstance(c, dict) else ""
+        group_tag = f"[{group}] " if group else ""
+        click.echo(f"{indent}{click.style('✓', fg='green')} {group_tag}{name}")
+
+
+def _render_attempt_log(
+    attempt: dict,
+    groups: list,
+    *,
+    prev_attempt: dict | None = None,
+    verbose: bool = False,
+) -> None:
+    """Render a single attempt with full detail for logs output."""
+    gate = "PASS" if attempt["verification_passed"] else "FAIL"
+    color = "green" if attempt["verification_passed"] else "red"
+    tokens = (attempt["token_input"] or 0) + (attempt["token_output"] or 0)
+
+    # Header line — include retry focus for attempt > 1
+    header = (
+        f"  #{attempt['attempt_number']}  {attempt['agent_id']:10s}  "
+        f"{click.style(gate, fg=color):4s}  "
+        f"{_fmt_tokens(tokens)}  {attempt['duration_s']:.0f}s"
+    )
+    if prev_attempt and prev_attempt.get("verification_result"):
+        try:
+            prev_vr = VerifierResult.from_json(prev_attempt["verification_result"])
+            failed_names = [c.criterion for c in prev_vr.failed_criteria[:3]]
+            if failed_names:
+                header += f" — focus: {', '.join(failed_names)}"
+        except (json.JSONDecodeError, KeyError):
+            pass
+    click.echo(header)
+
+    # Changed files
+    try:
+        changed = json.loads(attempt.get("changed_files", "[]"))
+    except (json.JSONDecodeError, TypeError):
+        changed = []
+    if changed:
+        click.echo(f"    changed: {_fmt_changed_files(changed)}")
+
+    # Criteria breakdown + suggestion
+    if attempt.get("verification_result"):
+        try:
+            vr = VerifierResult.from_json(attempt["verification_result"])
+            # Build criterion text → group_name mapping
+            criterion_to_group: dict[str, str] = {}
+            for g in groups:
+                for c in g.criteria:
+                    criterion_to_group[c.text] = g.name
+
+            criteria_data = {
+                "failed_criteria": [
+                    {
+                        "criterion": c.criterion,
+                        "group": criterion_to_group.get(c.criterion, ""),
+                        "detail": c.detail,
+                    }
+                    for c in vr.failed_criteria
+                ],
+                "passed_criteria": [
+                    {
+                        "criterion": c.criterion,
+                        "group": criterion_to_group.get(c.criterion, ""),
+                    }
+                    for c in vr.passed_criteria
+                ],
+            }
+            _render_criteria(criteria_data, verbose=verbose)
+            if verbose and vr.reason:
+                click.echo(f"    reason: {vr.reason}")
+            if vr.suggestion:
+                click.echo(f"    suggestion: {vr.suggestion}")
+        except (json.JSONDecodeError, KeyError):
+            pass
+
+
 def _render_event(event: dict) -> None:
     """Render a single event to terminal."""
     etype = event.get("type", "unknown")
@@ -889,17 +997,28 @@ def _render_event(event: dict) -> None:
     elif etype == "attempt_start":
         agent = event.get("agent_id", "?")
         attempt = event.get("attempt", "?")
-        click.echo(f"  [{agent}] attempt #{attempt} ...")
+        scope = event.get("scope")
+        if scope:
+            click.echo(f"  [{agent}] attempt #{attempt} — focus: {scope}")
+        else:
+            click.echo(f"  [{agent}] attempt #{attempt} ...")
     elif etype == "attempt_end":
         status = event.get("status", "?")
         tokens = event.get("token_input", 0) + event.get("token_output", 0)
         click.echo(f"  attempt done ({status}, {_fmt_tokens(tokens)})")
+        changed = event.get("changed_files", [])
+        if changed:
+            click.echo(f"    changed: {_fmt_changed_files(changed)}")
     elif etype == "verification":
         passed = event.get("passed", False)
         score = event.get("score", "?")
         color = "green" if passed else "red"
         label = "PASS" if passed else "FAIL"
         click.echo(f"  verify: {click.style(label, fg=color)} (score={score})")
+        _render_criteria(event)
+        suggestion = event.get("suggestion")
+        if suggestion:
+            click.echo(f"    suggestion: {suggestion}")
     elif etype == "group_start":
         name = event.get("group_name", event.get("group_id", "?"))
         click.echo(f"\nWorking on: {name}")
@@ -995,6 +1114,27 @@ def _print_mission(mission: dict, ws: Path, ledger: Ledger) -> None:
 
     groups = ledger.get_acceptance_groups(mission_id)
     if groups:
+        # Build per-group criteria counts from latest verification
+        group_passed_counts: dict[str, int] = {}
+        last_attempt = ledger.get_last_attempt(mission_id)
+        if last_attempt and last_attempt.get("verification_result"):
+            try:
+                vr = VerifierResult.from_json(last_attempt["verification_result"])
+                # Map criterion text → group name
+                criterion_to_group: dict[str, str] = {}
+                for g in groups:
+                    for c in g.criteria:
+                        criterion_to_group[c.text] = g.name
+                # Count passed per group
+                for c in vr.passed_criteria:
+                    gname = criterion_to_group.get(c.criterion, "")
+                    if gname:
+                        group_passed_counts[gname] = group_passed_counts.get(gname, 0) + 1
+            except (json.JSONDecodeError, KeyError):
+                logger.warning(
+                    "Could not parse verification_result for criteria counts"
+                )
+
         click.echo("\nAcceptance Checklist:")
         for g in groups:
             row = ledger.conn.execute(
@@ -1006,7 +1146,12 @@ def _print_mission(mission: dict, ws: Path, ledger: Ledger) -> None:
                 if completed
                 else click.style("○", fg="yellow")
             )
-            click.echo(f"  {marker} {g.name}")
+            total = len(g.criteria)
+            passed = group_passed_counts.get(g.name)
+            if passed is not None:
+                click.echo(f"  {marker} {g.name} ({passed}/{total})")
+            else:
+                click.echo(f"  {marker} {g.name} ({total} criteria)")
 
     attempts = ledger.get_attempts(mission_id)
     if attempts:
@@ -1068,6 +1213,8 @@ def logs(mission_id, last, verbose_logs, follow, json_output):
             if last:
                 attempts = attempts[-last:]
 
+            groups = ledger.get_acceptance_groups(mission_id)
+
             if json_output:
                 output = []
                 for a in attempts:
@@ -1080,6 +1227,12 @@ def logs(mission_id, last, verbose_logs, follow, json_output):
                         "token_output": a["token_output"],
                         "duration_s": a["duration_s"],
                     }
+                    try:
+                        entry["changed_files"] = json.loads(
+                            a.get("changed_files", "[]")
+                        )
+                    except (json.JSONDecodeError, TypeError):
+                        entry["changed_files"] = []
                     if verbose_logs and a.get("verification_result"):
                         try:
                             entry["verification_result"] = json.loads(
@@ -1090,25 +1243,11 @@ def logs(mission_id, last, verbose_logs, follow, json_output):
                     output.append(entry)
                 click.echo(json.dumps(output, indent=2))
             else:
-                for a in attempts:
-                    gate = "PASS" if a["verification_passed"] else "FAIL"
-                    color = "green" if a["verification_passed"] else "red"
-                    tokens = (a["token_input"] or 0) + (a["token_output"] or 0)
-                    click.echo(
-                        f"  #{a['attempt_number']}  {a['agent_id']:10s}  "
-                        f"{click.style(gate, fg=color):4s}  "
-                        f"{_fmt_tokens(tokens)}  {a['duration_s']:.0f}s"
+                for i, a in enumerate(attempts):
+                    prev = attempts[i - 1] if i > 0 else None
+                    _render_attempt_log(
+                        a, groups, prev_attempt=prev, verbose=verbose_logs
                     )
-                    if verbose_logs and a.get("verification_result"):
-                        try:
-                            vr = VerifierResult.from_json(a["verification_result"])
-                            if vr.failed_criteria:
-                                for c in vr.failed_criteria:
-                                    click.echo(f"    FAIL: {c.criterion}: {c.detail}")
-                            if vr.suggestion:
-                                click.echo(f"    Suggestion: {vr.suggestion}")
-                        except (json.JSONDecodeError, KeyError):
-                            pass
 
             return len(attempts)
 
@@ -1120,16 +1259,14 @@ def logs(mission_id, last, verbose_logs, follow, json_output):
             while True:
                 with Ledger(ws / "mission.db") as ledger:
                     attempts = ledger.get_attempts(mission_id)
+                    groups = ledger.get_acceptance_groups(mission_id)
                     if len(attempts) > seen:
                         new_attempts = attempts[seen:]
-                        for a in new_attempts:
-                            gate = "PASS" if a["verification_passed"] else "FAIL"
-                            color = "green" if a["verification_passed"] else "red"
-                            tokens = (a["token_input"] or 0) + (a["token_output"] or 0)
-                            click.echo(
-                                f"  #{a['attempt_number']}  {a['agent_id']:10s}  "
-                                f"{click.style(gate, fg=color):4s}  "
-                                f"{_fmt_tokens(tokens)}  {a['duration_s']:.0f}s"
+                        for i, a in enumerate(new_attempts):
+                            prev_idx = seen + i - 1
+                            prev = attempts[prev_idx] if prev_idx >= 0 else None
+                            _render_attempt_log(
+                                a, groups, prev_attempt=prev, verbose=verbose_logs
                             )
                         seen = len(attempts)
                     # Check if mission is still running

--- a/src/automission/loop.py
+++ b/src/automission/loop.py
@@ -7,7 +7,7 @@ import logging
 import subprocess
 import uuid
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable
 
 from automission.backend.protocol import AgentBackend
 from automission.db import Ledger
@@ -262,6 +262,7 @@ def _run_one_iteration(
     dirty_state = _get_dirty_state(workdir)
 
     # ── Build prompt ──
+    contract = None
     if last_verification is None:
         # First attempt
         prompt = _build_first_attempt_prompt(
@@ -289,14 +290,14 @@ def _run_one_iteration(
     )
     logger.info("Running attempt %s (#%d)", attempt_id, attempt_number)
     if event_writer:
-        event_writer.emit(
-            "attempt_start",
-            {
-                "agent_id": agent_id,
-                "attempt": attempt_number,
-                "attempt_id": attempt_id,
-            },
-        )
+        start_data: dict[str, Any] = {
+            "agent_id": agent_id,
+            "attempt": attempt_number,
+            "attempt_id": attempt_id,
+        }
+        if contract is not None:
+            start_data["scope"] = contract.scope
+        event_writer.emit("attempt_start", start_data)
     attempt_result = backend.run_attempt(spec)
 
     # ── Auto-commit ──
@@ -351,12 +352,32 @@ def _run_one_iteration(
                 "changed_files": attempt_result.changed_files,
             },
         )
+        # Build criterion → group_name mapping for display
+        criterion_group_map: dict[str, str] = {}
+        for g in groups:
+            for c in g.criteria:
+                criterion_group_map[c.text] = g.name
+
         event_writer.emit(
             "verification",
             {
                 "passed": verification.contract_passed,
                 "score": verification.score,
-                "failed_criteria": [c.criterion for c in verification.failed_criteria],
+                "failed_criteria": [
+                    {
+                        "criterion": c.criterion,
+                        "group": criterion_group_map.get(c.criterion, ""),
+                    }
+                    for c in verification.failed_criteria
+                ],
+                "passed_criteria": [
+                    {
+                        "criterion": c.criterion,
+                        "group": criterion_group_map.get(c.criterion, ""),
+                    }
+                    for c in verification.passed_criteria
+                ],
+                "suggestion": verification.suggestion,
             },
         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1029,3 +1029,202 @@ class TestExportCommand:
 
         assert result.exit_code != 0
         assert "not found" in result.output
+
+
+# ── Rich output helpers ──
+
+
+class TestFmtChangedFiles:
+    """Tests for _fmt_changed_files helper."""
+
+    def test_empty(self):
+        from automission.cli import _fmt_changed_files
+
+        assert _fmt_changed_files([]) == ""
+
+    def test_single_file(self):
+        from automission.cli import _fmt_changed_files
+
+        result = _fmt_changed_files(["src/main.py"])
+        assert "main.py" in result
+        assert "(1 file)" in result
+
+    def test_multiple_files(self):
+        from automission.cli import _fmt_changed_files
+
+        result = _fmt_changed_files(["src/a.py", "src/b.py", "tests/test_c.py"])
+        assert "a.py" in result
+        assert "b.py" in result
+        assert "test_c.py" in result
+        assert "(3 files)" in result
+
+    def test_truncation(self):
+        from automission.cli import _fmt_changed_files
+
+        files = [f"src/file{i}.py" for i in range(8)]
+        result = _fmt_changed_files(files, max_shown=3)
+        assert "+5 more" in result
+        assert "(8 files)" in result
+
+
+class TestRenderCriteria:
+    """Tests for _render_criteria helper."""
+
+    def test_failed_and_passed(self, capsys):
+        from automission.cli import _render_criteria
+
+        event = {
+            "failed_criteria": [
+                {"criterion": "CLI rejects missing expression", "group": "input_handling"},
+            ],
+            "passed_criteria": [
+                {"criterion": "1+1 returns 2", "group": "basic_arithmetic"},
+            ],
+        }
+        _render_criteria(event)
+        out = capsys.readouterr().out
+        assert "✗" in out
+        assert "[input_handling]" in out
+        assert "CLI rejects missing expression" in out
+        assert "✓" in out
+        assert "[basic_arithmetic]" in out
+        assert "1+1 returns 2" in out
+
+    def test_verbose_detail(self, capsys):
+        from automission.cli import _render_criteria
+
+        event = {
+            "failed_criteria": [
+                {
+                    "criterion": "Division by zero",
+                    "group": "error_handling",
+                    "detail": "got exit code 0",
+                },
+            ],
+            "passed_criteria": [],
+        }
+        _render_criteria(event, verbose=True)
+        out = capsys.readouterr().out
+        assert "→ got exit code 0" in out
+
+    def test_no_group(self, capsys):
+        from automission.cli import _render_criteria
+
+        event = {
+            "failed_criteria": [{"criterion": "some criterion", "group": ""}],
+            "passed_criteria": [],
+        }
+        _render_criteria(event)
+        out = capsys.readouterr().out
+        assert "some criterion" in out
+        # No [group] tag when group is empty
+        assert "[]" not in out
+
+    def test_empty_criteria(self, capsys):
+        from automission.cli import _render_criteria
+
+        _render_criteria({"failed_criteria": [], "passed_criteria": []})
+        out = capsys.readouterr().out
+        assert out == ""
+
+
+class TestRenderEventRichOutput:
+    """Tests for enriched _render_event output."""
+
+    def test_attempt_start_with_scope(self, capsys):
+        from automission.cli import _render_event
+
+        event = {
+            "type": "attempt_start",
+            "agent_id": "agent-1",
+            "attempt": 2,
+            "scope": "Fix: input validation",
+        }
+        _render_event(event)
+        out = capsys.readouterr().out
+        assert "agent-1" in out
+        assert "#2" in out
+        assert "focus: Fix: input validation" in out
+
+    def test_attempt_start_without_scope(self, capsys):
+        from automission.cli import _render_event
+
+        event = {"type": "attempt_start", "agent_id": "agent-1", "attempt": 1}
+        _render_event(event)
+        out = capsys.readouterr().out
+        assert "#1 ..." in out
+        assert "focus" not in out
+
+    def test_attempt_end_with_changed_files(self, capsys):
+        from automission.cli import _render_event
+
+        event = {
+            "type": "attempt_end",
+            "status": "completed",
+            "token_input": 50000,
+            "token_output": 10000,
+            "changed_files": ["calculator.py", "tests/test_calc.py"],
+        }
+        _render_event(event)
+        out = capsys.readouterr().out
+        assert "completed" in out
+        assert "60.0k tokens" in out
+        assert "changed:" in out
+        assert "calculator.py" in out
+
+    def test_attempt_end_no_changed_files(self, capsys):
+        from automission.cli import _render_event
+
+        event = {
+            "type": "attempt_end",
+            "status": "completed",
+            "token_input": 1000,
+            "token_output": 500,
+            "changed_files": [],
+        }
+        _render_event(event)
+        out = capsys.readouterr().out
+        assert "changed" not in out
+
+    def test_verification_with_criteria_and_suggestion(self, capsys):
+        from automission.cli import _render_event
+
+        event = {
+            "type": "verification",
+            "passed": False,
+            "score": 0.4,
+            "failed_criteria": [
+                {"criterion": "CLI rejects missing expression", "group": "input_handling"},
+            ],
+            "passed_criteria": [
+                {"criterion": "1+1 returns 2", "group": "basic_arithmetic"},
+            ],
+            "suggestion": "Fix subprocess call to use relative path",
+        }
+        _render_event(event)
+        out = capsys.readouterr().out
+        assert "FAIL" in out
+        assert "score=0.4" in out
+        assert "✗" in out
+        assert "[input_handling]" in out
+        assert "✓" in out
+        assert "[basic_arithmetic]" in out
+        assert "suggestion: Fix subprocess call" in out
+
+    def test_verification_pass_no_suggestion(self, capsys):
+        from automission.cli import _render_event
+
+        event = {
+            "type": "verification",
+            "passed": True,
+            "score": 1.0,
+            "failed_criteria": [],
+            "passed_criteria": [
+                {"criterion": "All tests pass", "group": "testing"},
+            ],
+            "suggestion": "",
+        }
+        _render_event(event)
+        out = capsys.readouterr().out
+        assert "PASS" in out
+        assert "suggestion" not in out

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -434,3 +434,131 @@ class TestRunLoop:
         )
         prompt = backend.attempts[0].prompt
         assert "partial.py" in prompt or "uncommitted" in prompt.lower()
+
+
+class TestEventEnrichment:
+    """Test that events contain enriched data for CLI display."""
+
+    def test_verification_event_includes_criteria_and_suggestion(
+        self, tmp_path, fixture_dir
+    ):
+        """Verification event should include passed/failed criteria and suggestion."""
+        from automission.events import EventWriter, EventTailer
+
+        backend = MockBackend(
+            simulate_files={"src/calc.py": "def add(a, b): return a + b\n"},
+        )
+        ws = create_mission(
+            mission_id="evt-001",
+            goal="Build calculator",
+            acceptance_path=fixture_dir / "ACCEPTANCE.md",
+            verify_path=fixture_dir / "verify.sh",
+            backend=backend,
+            workspace_dir=tmp_path / "ws",
+            init_files_dir=fixture_dir / "workspace",
+        )
+        verifier = Verifier()
+        with EventWriter(ws / "events.jsonl") as ew:
+            run_loop(
+                mission_id="evt-001",
+                workdir=ws,
+                backend=backend,
+                verifier=verifier,
+                max_iterations=1,
+                max_cost=10.0,
+                timeout=3600,
+                event_writer=ew,
+            )
+
+        events = list(EventTailer(ws / "events.jsonl").read_existing())
+        verify_events = [e for e in events if e["type"] == "verification"]
+        assert len(verify_events) == 1
+
+        ve = verify_events[0]
+        # Should have structured criteria (dicts, not plain strings)
+        assert "passed_criteria" in ve
+        assert "failed_criteria" in ve
+        assert "suggestion" in ve
+        # Criteria should be dicts with criterion and group keys
+        for c in ve["failed_criteria"] + ve["passed_criteria"]:
+            assert "criterion" in c
+            assert "group" in c
+
+    def test_attempt_end_event_includes_changed_files(
+        self, tmp_path, fixture_dir
+    ):
+        """attempt_end event should include changed_files list."""
+        from automission.events import EventWriter, EventTailer
+
+        backend = MockBackend(
+            simulate_files={"src/calc.py": CALC_PY},
+        )
+        ws = create_mission(
+            mission_id="evt-002",
+            goal="Build calculator",
+            acceptance_path=fixture_dir / "ACCEPTANCE.md",
+            verify_path=fixture_dir / "verify.sh",
+            backend=backend,
+            workspace_dir=tmp_path / "ws",
+            init_files_dir=fixture_dir / "workspace",
+        )
+        verifier = Verifier()
+        with EventWriter(ws / "events.jsonl") as ew:
+            run_loop(
+                mission_id="evt-002",
+                workdir=ws,
+                backend=backend,
+                verifier=verifier,
+                max_iterations=1,
+                max_cost=10.0,
+                timeout=3600,
+                event_writer=ew,
+            )
+
+        events = list(EventTailer(ws / "events.jsonl").read_existing())
+        end_events = [e for e in events if e["type"] == "attempt_end"]
+        assert len(end_events) == 1
+        assert "changed_files" in end_events[0]
+        assert isinstance(end_events[0]["changed_files"], list)
+
+    def test_retry_attempt_start_includes_scope(self, tmp_path, fixture_dir):
+        """attempt_start on retry should include contract scope."""
+        from automission.events import EventWriter, EventTailer
+
+        # First attempt fails (incomplete calc), second attempt should have scope
+        backend = MockBackend(
+            simulate_sequence=[
+                {"src/calc.py": "def add(a, b): return a + b\n"},
+                {"src/calc.py": CALC_PY},
+            ],
+        )
+        ws = create_mission(
+            mission_id="evt-003",
+            goal="Build calculator",
+            acceptance_path=fixture_dir / "ACCEPTANCE.md",
+            verify_path=fixture_dir / "verify.sh",
+            backend=backend,
+            workspace_dir=tmp_path / "ws",
+            init_files_dir=fixture_dir / "workspace",
+        )
+        verifier = Verifier()
+        with EventWriter(ws / "events.jsonl") as ew:
+            run_loop(
+                mission_id="evt-003",
+                workdir=ws,
+                backend=backend,
+                verifier=verifier,
+                max_iterations=3,
+                max_cost=10.0,
+                timeout=3600,
+                event_writer=ew,
+            )
+
+        events = list(EventTailer(ws / "events.jsonl").read_existing())
+        start_events = [e for e in events if e["type"] == "attempt_start"]
+        assert len(start_events) >= 2
+        # First attempt should NOT have scope
+        assert "scope" not in start_events[0] or start_events[0].get("scope") is None
+        # Second attempt SHOULD have scope
+        assert "scope" in start_events[1]
+        assert start_events[1]["scope"]  # non-empty


### PR DESCRIPTION
## Summary

- Enrich live view events with changed files, per-criterion pass/fail (with group tags), verification suggestions, and retry focus scope
- Add criteria progress counts `(passed/total)` to `status` acceptance checklist
- Upgrade `logs` default output to show full attempt breakdown: changed files, all criteria results, and suggestions
- `logs -v` adds criterion detail text and verification reason
- `logs --follow` and `logs --json` also benefit from the enriched output

## Changes

**`loop.py`** — Event data enrichment:
- `attempt_start` event includes `scope` on retries (contract focus)
- `verification` event includes structured `passed_criteria`, `failed_criteria` (with group mapping), and `suggestion`

**`cli.py`** — Display layer:
- New helpers: `_fmt_changed_files()`, `_render_criteria()`, `_render_attempt_log()`
- `_render_event()`: attempt_start shows retry focus, attempt_end shows changed files, verification shows per-criterion results + suggestion
- `_print_mission()` (status): acceptance checklist shows `(passed/total)` counts per group
- `logs` command: default mode shows full breakdown, `-v` adds detail/reason, `--follow` uses same rendering, `--json` includes `changed_files`

## Test plan

- [x] `_fmt_changed_files` — empty, single, multiple, truncation
- [x] `_render_criteria` — failed+passed, verbose detail, no group, empty
- [x] `_render_event` — attempt_start with/without scope, attempt_end with/without files, verification with criteria+suggestion
- [x] Event enrichment integration — verification events include structured criteria, attempt_end includes changed_files, retry attempt_start includes scope
- [x] Full test suite: 415 passed, 15 skipped

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)