### PR TITLE
fix: remove _basic_critic fallback that caused target_groups filter to discard valid LLM results

### DIFF
--- a/src/automission/loop.py
+++ b/src/automission/loop.py
@@ -331,14 +331,7 @@ def _run_one_iteration(
 
     # ── Update group statuses ──
     if verification.group_statuses:
-        statuses = verification.group_statuses
-        if target_groups is not None:
-            # Only update statuses for target groups to avoid marking
-            # unevaluated groups as complete (basic_critic marks all True/False)
-            target_ids = {g.id for g in target_groups}
-            statuses = {k: v for k, v in statuses.items() if k in target_ids}
-        if statuses:
-            ledger.update_group_statuses(statuses)
+        ledger.update_group_statuses(verification.group_statuses)
 
     if event_writer:
         event_writer.emit(

--- a/src/automission/verifier.py
+++ b/src/automission/verifier.py
@@ -173,7 +173,7 @@ class Verifier:
 
     def __init__(
         self,
-        backend: StructuredOutputBackend | None = None,
+        backend: StructuredOutputBackend,
         verifier_model: str = "claude-sonnet-4-6",
         docker_image: str = "ghcr.io/codance-ai/automission:latest",
     ):
@@ -218,10 +218,7 @@ class Verifier:
             metrics = jo.get("metrics", {})
 
         # ── Critic ──
-        if self.backend is not None:
-            critic = self._run_critic(gate, acceptance_groups)
-        else:
-            critic = self._basic_critic(gate_passed, acceptance_groups)
+        critic = self._run_critic(gate, acceptance_groups)
 
         # ── Combine ──
         contract_passed = gate_passed
@@ -293,39 +290,24 @@ Be specific about what passed and what failed. Provide an actionable suggestion 
                     }
                 except (KeyError, TypeError) as e:
                     logger.warning("Malformed group_statuses from critic: %s", e)
-                    return self._basic_critic(gate["passed"], groups)
+                    return self._empty_critic(str(e))
             return result
         except CLIResponseError as e:
             logger.error("Critic CLI call failed: %s", e)
-            return self._basic_critic(gate["passed"], groups)
+            return self._empty_critic(str(e))
 
-    def _basic_critic(
-        self, gate_passed: bool, groups: list[AcceptanceGroup]
-    ) -> dict[str, Any]:
-        """Fallback critic when no LLM client is available."""
-        if gate_passed:
-            return {
-                "passed_criteria": [
-                    {"criterion": c.text, "passed": True, "detail": "Gate passed"}
-                    for g in groups
-                    for c in g.criteria
-                ],
-                "failed_criteria": [],
-                "group_statuses": {g.id: True for g in groups},
-                "suggestion": "",
-                "reason": "All gate checks passed.",
-                "score": 1.0,
-            }
-        else:
-            return {
-                "passed_criteria": [],
-                "failed_criteria": [
-                    {"criterion": c.text, "passed": False, "detail": "Gate failed"}
-                    for g in groups
-                    for c in g.criteria
-                ],
-                "group_statuses": {g.id: False for g in groups},
-                "suggestion": "Review the test output and fix failing tests.",
-                "reason": "Gate verification failed.",
-                "score": 0.0,
-            }
+    @staticmethod
+    def _empty_critic(error: str) -> dict[str, Any]:
+        """Return empty critic result when LLM call fails.
+
+        Does not fabricate group statuses — downstream code will see no
+        group progress for this attempt and retry.
+        """
+        return {
+            "passed_criteria": [],
+            "failed_criteria": [],
+            "group_statuses": {},
+            "suggestion": "Critic evaluation failed, retry.",
+            "reason": f"Critic error: {error}",
+            "score": None,
+        }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,61 @@
 """Shared test fixtures."""
 
+import re
 import subprocess as _subprocess
 from pathlib import Path
 
 import pytest
+
+
+class MockCriticBackend:
+    """Mock StructuredOutputBackend that evaluates based on gate result in the prompt.
+
+    Parses the critic prompt to determine gate pass/fail and group IDs,
+    then returns appropriate per-group statuses. Used in tests as a
+    deterministic replacement for the real LLM critic.
+    """
+
+    def query(
+        self, prompt: str, model: str, json_schema: dict, timeout: int = 300
+    ) -> dict:
+        gate_passed = "Passed: True" in prompt
+        # Extract group IDs from "## Groups\n<id1>, <id2>"
+        groups_match = re.search(r"## Groups\n(.+)", prompt)
+        group_ids = (
+            [g.strip() for g in groups_match.group(1).split(",")]
+            if groups_match
+            else []
+        )
+        # Extract criteria from "- [group_name] criterion_text"
+        criteria = re.findall(r"- \[.+?\] (.+)", prompt)
+
+        if gate_passed:
+            return {
+                "passed_criteria": [
+                    {"criterion": c, "passed": True, "detail": "Gate passed"}
+                    for c in criteria
+                ],
+                "failed_criteria": [],
+                "group_statuses": [
+                    {"group_id": gid, "completed": True} for gid in group_ids
+                ],
+                "suggestion": "",
+                "reason": "All gate checks passed.",
+                "score": 1.0,
+            }
+        return {
+            "passed_criteria": [],
+            "failed_criteria": [
+                {"criterion": c, "passed": False, "detail": "Gate failed"}
+                for c in criteria
+            ],
+            "group_statuses": [
+                {"group_id": gid, "completed": False} for gid in group_ids
+            ],
+            "suggestion": "Review the test output and fix failing tests.",
+            "reason": "Gate verification failed.",
+            "score": 0.0,
+        }
 
 
 @pytest.fixture

--- a/tests/test_acceptance_graph.py
+++ b/tests/test_acceptance_graph.py
@@ -364,8 +364,9 @@ class TestSingleAgentFrontierLoop:
         from automission.executor import _run_single_agent_frontier
         from automission.events import EventWriter
         from automission.verifier import Verifier
+        from conftest import MockCriticBackend
 
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
         with EventWriter(ws / "events.jsonl") as ew:
             outcome = _run_single_agent_frontier(
                 mission_id="dag-001",
@@ -416,8 +417,9 @@ class TestSingleAgentFrontierLoop:
         from automission.executor import _run_single_agent_frontier
         from automission.events import EventWriter
         from automission.verifier import Verifier
+        from conftest import MockCriticBackend
 
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
         with EventWriter(ws / "events.jsonl") as ew:
             _run_single_agent_frontier(
                 mission_id="dag-002",

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -10,6 +10,7 @@ from automission.db import Ledger
 from automission.loop import run_loop, run_single_iteration
 from automission.orchestrator import run_multi_agent
 from automission.verifier import Verifier
+from conftest import MockCriticBackend
 from automission.workspace import create_mission
 
 
@@ -68,7 +69,7 @@ class TestE2EPassingMission:
         assert (ws / "src" / "tests" / "test_calc.py").exists()
 
         # 4. Run single iteration
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
         result = run_single_iteration(
             mission_id="e2e-001",
             workdir=ws,
@@ -112,7 +113,7 @@ class TestE2EPassingMission:
             init_files_dir=fixture_dir / "workspace",
         )
 
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
         run_single_iteration(
             mission_id="e2e-002",
             workdir=ws,
@@ -147,7 +148,7 @@ class TestE2EFailingMission:
             init_files_dir=fixture_dir / "workspace",
         )
 
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
         result = run_single_iteration(
             mission_id="e2e-fail",
             workdir=ws,
@@ -239,7 +240,7 @@ class TestE2EMultiIteration:
             workspace_dir=tmp_path / "ws",
             init_files_dir=fixture_dir / "workspace",
         )
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
 
         outcome = run_loop(
             mission_id="e2e-loop",
@@ -281,7 +282,7 @@ class TestE2EMultiIteration:
             workspace_dir=tmp_path / "ws",
             init_files_dir=fixture_dir / "workspace",
         )
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
 
         run_loop(
             mission_id="e2e-feedback",
@@ -311,7 +312,7 @@ class TestE2EMultiIteration:
             workspace_dir=tmp_path / "ws",
             init_files_dir=fixture_dir / "workspace",
         )
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
 
         outcome = run_loop(
             mission_id="e2e-breaker",
@@ -354,7 +355,7 @@ class TestE2EMultiAgent:
             ["git", "commit", "-m", "fix verify.sh"], cwd=ws, capture_output=True
         )
 
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
 
         outcome = run_multi_agent(
             mission_id="e2e-multi",

--- a/tests/test_e2e_real.py
+++ b/tests/test_e2e_real.py
@@ -23,6 +23,7 @@ from automission.db import Ledger
 from automission.loop import run_loop
 from automission.orchestrator import run_multi_agent
 from automission.verifier import Verifier
+from conftest import MockCriticBackend
 from automission.workspace import create_mission
 
 # ── Skip conditions ──
@@ -138,7 +139,7 @@ class TestSingleAgentCalculator:
             docker_image=DOCKER_IMAGE,
         )
 
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
         outcome = run_loop(
             mission_id=f"real-calc-{backend_name}",
             workdir=ws,
@@ -210,7 +211,7 @@ class TestPlannerFlow:
         )
 
         # Step 3: Run agent loop
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
         outcome = run_loop(
             mission_id=f"real-planner-{backend_name}",
             workdir=ws,
@@ -259,7 +260,7 @@ class TestMultiAgent:
             docker_image=DOCKER_IMAGE,
         )
 
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
         outcome = run_multi_agent(
             mission_id=f"real-multi-{backend_name}",
             mission_dir=ws,
@@ -309,7 +310,7 @@ class TestCircuitBreaker:
             docker_image=DOCKER_IMAGE,
         )
 
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
         outcome = run_loop(
             mission_id=f"real-breaker-{backend_name}",
             workdir=ws,
@@ -364,7 +365,7 @@ class TestIterationWithFeedback:
             docker_image=DOCKER_IMAGE,
         )
 
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
         outcome = run_loop(
             mission_id=f"real-iter-{backend_name}",
             workdir=ws,

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -10,6 +10,7 @@ from automission.db import Ledger
 from automission.loop import run_single_iteration, run_loop
 from automission.models import VerifierResult
 from automission.verifier import Verifier
+from conftest import MockCriticBackend
 from automission.workspace import create_mission
 
 
@@ -58,7 +59,7 @@ def mission_workspace(tmp_path, fixture_dir):
 class TestRunSingleIteration:
     def test_attempt_runs_and_records(self, mission_workspace):
         ws, backend = mission_workspace
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
 
         run_single_iteration(
             mission_id="test-001",
@@ -76,7 +77,7 @@ class TestRunSingleIteration:
 
     def test_returns_verifier_result(self, mission_workspace):
         ws, backend = mission_workspace
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
 
         result = run_single_iteration(
             mission_id="test-001",
@@ -90,7 +91,7 @@ class TestRunSingleIteration:
 
     def test_auto_commits_changes(self, mission_workspace):
         ws, backend = mission_workspace
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
 
         run_single_iteration(
             mission_id="test-001",
@@ -108,7 +109,7 @@ class TestRunSingleIteration:
 
     def test_prompt_contains_instructions(self, mission_workspace):
         ws, backend = mission_workspace
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
 
         run_single_iteration(
             mission_id="test-001",
@@ -126,7 +127,7 @@ class TestRunSingleIteration:
         """When verify.sh passes and basic critic says all groups done, mission completed."""
         ws, backend = mission_workspace
         # Basic critic (no LLM) marks all groups as passed when gate passes
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
 
         result = run_single_iteration(
             mission_id="test-001",
@@ -161,7 +162,7 @@ class TestRunLoop:
             workspace_dir=tmp_path / "ws",
             init_files_dir=fixture_dir / "workspace",
         )
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
         outcome = run_loop(
             mission_id="loop-001",
             workdir=ws,
@@ -190,7 +191,7 @@ class TestRunLoop:
             workspace_dir=tmp_path / "ws",
             init_files_dir=fixture_dir / "workspace",
         )
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
         outcome = run_loop(
             mission_id="loop-iter",
             workdir=ws,
@@ -219,7 +220,7 @@ class TestRunLoop:
             workspace_dir=tmp_path / "ws",
             init_files_dir=fixture_dir / "workspace",
         )
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
         outcome = run_loop(
             mission_id="loop-cost",
             workdir=ws,
@@ -251,7 +252,7 @@ class TestRunLoop:
             workspace_dir=tmp_path / "ws",
             init_files_dir=fixture_dir / "workspace",
         )
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
         run_loop(
             mission_id="loop-feedback",
             workdir=ws,
@@ -278,7 +279,7 @@ class TestRunLoop:
             workspace_dir=tmp_path / "ws",
             init_files_dir=fixture_dir / "workspace",
         )
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
         call_count = 0
 
         def cancel_after_one():
@@ -317,7 +318,7 @@ class TestRunLoop:
             workspace_dir=tmp_path / "ws",
             init_files_dir=fixture_dir / "workspace",
         )
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
         # Cancel after first attempt
         call_count = 0
 
@@ -370,7 +371,7 @@ class TestRunLoop:
             workspace_dir=tmp_path / "ws",
             init_files_dir=fixture_dir / "workspace",
         )
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
         outcome = run_loop(
             mission_id="loop-stall",
             workdir=ws,
@@ -396,7 +397,7 @@ class TestRunLoop:
             workspace_dir=tmp_path / "ws",
             init_files_dir=fixture_dir / "workspace",
         )
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
         outcome = run_loop(
             mission_id="loop-sep",
             workdir=ws,
@@ -422,7 +423,7 @@ class TestRunLoop:
         )
         # Create dirty state
         (ws / "src" / "partial.py").write_text("# partial work\n")
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
         run_loop(
             mission_id="loop-dirty",
             workdir=ws,
@@ -457,7 +458,7 @@ class TestEventEnrichment:
             workspace_dir=tmp_path / "ws",
             init_files_dir=fixture_dir / "workspace",
         )
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
         with EventWriter(ws / "events.jsonl") as ew:
             run_loop(
                 mission_id="evt-001",
@@ -500,7 +501,7 @@ class TestEventEnrichment:
             workspace_dir=tmp_path / "ws",
             init_files_dir=fixture_dir / "workspace",
         )
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
         with EventWriter(ws / "events.jsonl") as ew:
             run_loop(
                 mission_id="evt-002",
@@ -539,7 +540,7 @@ class TestEventEnrichment:
             workspace_dir=tmp_path / "ws",
             init_files_dir=fixture_dir / "workspace",
         )
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
         with EventWriter(ws / "events.jsonl") as ew:
             run_loop(
                 mission_id="evt-003",

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -10,6 +10,7 @@ from automission.backend.mock import MockBackend
 from automission.db import Ledger
 from automission.orchestrator import run_multi_agent
 from automission.verifier import Verifier
+from conftest import MockCriticBackend
 from automission.workspace import create_mission
 
 
@@ -117,7 +118,7 @@ class TestRunMultiAgent:
             init_files_dir=fixture_dir / "workspace",
             agents=2,
         )
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
 
         outcome = run_multi_agent(
             mission_id="orch-001",
@@ -162,7 +163,7 @@ class TestRunMultiAgent:
             init_files_dir=fixture_dir / "workspace",
             agents=2,
         )
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
 
         call_count = 0
         lock = threading.Lock()
@@ -190,7 +191,7 @@ class TestRunMultiAgent:
     def test_single_agent_completes(self, orch_workspace):
         """Single agent mode should work correctly through orchestrator."""
         ws, backend = orch_workspace
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
 
         outcome = run_multi_agent(
             mission_id="orch-test",
@@ -229,7 +230,7 @@ class TestRunMultiAgent:
             init_files_dir=fixture_dir / "workspace",
             agents=2,
         )
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
 
         run_multi_agent(
             mission_id="orch-cleanup",
@@ -273,7 +274,7 @@ class TestRunMultiAgent:
             agents=2,
             max_iterations=3,
         )
-        verifier = Verifier()
+        verifier = Verifier(backend=MockCriticBackend())
 
         outcome = run_multi_agent(
             mission_id="orch-limit",

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -73,28 +73,6 @@ class TestVerifyShGate:
 
 
 class TestVerifier:
-    def test_gate_pass_no_critic(self, workspace, sample_groups):
-        script = workspace / "verify.sh"
-        script.write_text("#!/bin/bash\nexit 0\n")
-        script.chmod(0o755)
-
-        verifier = Verifier()
-        result = verifier.evaluate(workspace, script, sample_groups)
-
-        assert result.contract_passed is True
-        assert result.gate_source == "script"
-
-    def test_gate_fail_no_critic(self, workspace, sample_groups):
-        script = workspace / "verify.sh"
-        script.write_text("#!/bin/bash\necho 'test_add FAILED'\nexit 1\n")
-        script.chmod(0o755)
-
-        verifier = Verifier()
-        result = verifier.evaluate(workspace, script, sample_groups)
-
-        assert result.contract_passed is False
-        assert result.gate_source == "script"
-
     def test_with_mock_critic(self, workspace, sample_groups):
         script = workspace / "verify.sh"
         script.write_text("#!/bin/bash\necho 'test_add FAILED'\nexit 1\n")
@@ -182,10 +160,10 @@ class TestVerifier:
         assert result.group_statuses == {"basic": False}
         assert isinstance(result.group_statuses, dict)
 
-    def test_malformed_group_statuses_falls_back_to_basic(
+    def test_malformed_group_statuses_returns_empty_critic(
         self, workspace, sample_groups
     ):
-        """Malformed array entries in group_statuses trigger basic_critic fallback."""
+        """Malformed array entries in group_statuses return empty critic (no fabricated data)."""
         script = workspace / "verify.sh"
         script.write_text("#!/bin/bash\nexit 1\n")
         script.chmod(0o755)
@@ -204,11 +182,11 @@ class TestVerifier:
         verifier = Verifier(backend=backend, verifier_model="claude-sonnet-4-6")
         result = verifier.evaluate(workspace, script, sample_groups)
 
-        # Should fall back to basic critic instead of crashing
-        assert result.reason == "Gate verification failed."
-        assert isinstance(result.group_statuses, dict)
+        # Should return empty critic result instead of crashing
+        assert result.group_statuses == {}
+        assert "Critic error" in result.reason
 
-    def test_critic_cli_failure_falls_back_to_basic(self, workspace, sample_groups):
+    def test_critic_cli_failure_returns_empty_critic(self, workspace, sample_groups):
         script = workspace / "verify.sh"
         script.write_text("#!/bin/bash\nexit 1\n")
         script.chmod(0o755)
@@ -220,6 +198,7 @@ class TestVerifier:
         verifier = Verifier(backend=backend, verifier_model="claude-sonnet-4-6")
         result = verifier.evaluate(workspace, script, sample_groups)
 
-        # Should fall back to basic critic
+        # Should return empty critic, not fabricated data
         assert result.contract_passed is False
-        assert result.reason == "Gate verification failed."
+        assert result.group_statuses == {}
+        assert "Critic error" in result.reason


### PR DESCRIPTION
## Summary

- Removed `_basic_critic` fallback from `Verifier` — it blindly marked all groups as pass/fail based solely on gate result, producing unreliable data
- Removed `target_groups` filter in `loop.py:335-339` — this filter was compensating for `_basic_critic`'s unreliable data but also discarded valid LLM critic evaluations for non-target groups
- Made `backend` (LLM) required for `Verifier` — no more degraded mode that fabricates group statuses
- On LLM critic failure, returns empty result (no fabricated data) instead of falling back to `_basic_critic`

## Impact

When the LLM critic confirms all groups pass in a single attempt, all groups are now correctly marked as complete. Previously, only the target group's result was kept, forcing redundant re-verification of already-passing groups (~500k+ tokens wasted per mission).

## Test plan

- [x] All 418 tests pass (15 skipped — real API tests)
- [x] `ruff check` passes
- [x] Verified `test_malformed_group_statuses_returns_empty_critic` — returns empty result, not fabricated data
- [x] Verified `test_critic_cli_failure_returns_empty_critic` — same behavior on LLM failure
- [x] Verified `test_frontier_loop_sequences_groups` — frontier sequencing still works correctly

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)