### PR TITLE
chore: update outdated comment referencing removed _basic_critic

### DIFF
--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -124,9 +124,9 @@ class TestRunSingleIteration:
         assert "verify.sh" in prompt
 
     def test_passing_mission_marked_completed(self, mission_workspace):
-        """When verify.sh passes and basic critic says all groups done, mission completed."""
+        """When verify.sh passes and critic says all groups done, mission completed."""
         ws, backend = mission_workspace
-        # Basic critic (no LLM) marks all groups as passed when gate passes
+        # MockCriticBackend marks all groups as passed when gate passes
         verifier = Verifier(backend=MockCriticBackend())
 
         result = run_single_iteration(


### PR DESCRIPTION
Follow-up to #31 — update stale comment that still referenced the removed `_basic_critic`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)