### PR TITLE
fix: inherit git user config in agent workspace clone

### DIFF
--- a/src/automission/worktree.py
+++ b/src/automission/worktree.py
@@ -34,6 +34,22 @@ def create_agent_worktree(mission_dir: Path, agent_id: str) -> Path:
         check=True,
     )
 
+    # Inherit git user config from source repo (clones don't copy local config;
+    # without this, git commit fails in CI where no global config exists).
+    for key in ("user.email", "user.name"):
+        result = subprocess.run(
+            ["git", "config", key],
+            cwd=mission_dir,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            subprocess.run(
+                ["git", "config", key, result.stdout.strip()],
+                cwd=workspace_path,
+                capture_output=True,
+            )
+
     # Create and checkout agent work branch
     subprocess.run(
         ["git", "checkout", "-b", f"{agent_id}-work"],


### PR DESCRIPTION
## Summary

Fix CI failure from #33: `git clone --local` does not copy the source repo's local git config. In CI environments without global git config, `git commit` in the clone fails with exit code 128 (author identity unknown).

Copies `user.email` and `user.name` from the source repo to the clone after creation.

## Test plan

- [x] All 10 worktree + merge tests pass locally
- [ ] CI should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)