### PR TITLE
Fix code review findings from verification pipeline restructure

### DIFF
--- a/src/automission/db.py
+++ b/src/automission/db.py
@@ -549,23 +549,16 @@ class Ledger:
         return dict(row) if row else None
 
     def get_best_attempt(self, mission_id: str) -> dict | None:
-        """Get the attempt with the highest verification score."""
+        """Get the most recent attempt where the gate passed.
+
+        Used for rollback: when stall detection triggers, we reset to
+        the last known-good commit. Returns None if no attempt passed.
+        """
         attempts = self.get_attempts(mission_id)
-        best = None
-        best_score = -1.0
-        for a in attempts:
-            vr_raw = a.get("verification_result", "")
-            if not vr_raw:
-                continue
-            try:
-                vr = json.loads(vr_raw)
-                score = vr.get("score")
-                if score is not None and score > best_score:
-                    best_score = score
-                    best = a
-            except (json.JSONDecodeError, KeyError):
-                continue
-        return best
+        for a in reversed(attempts):
+            if a.get("verification_passed"):
+                return a
+        return None
 
     def get_mission_age_s(self, mission_id: str) -> float | None:
         """Get seconds elapsed since mission creation."""

--- a/src/automission/loop.py
+++ b/src/automission/loop.py
@@ -150,7 +150,7 @@ def run_loop(
 
             # ── Stall detection (pre-iteration) ──
             stall_hint = False
-            stall_count = _count_stall(ledger, mission_id, stall_threshold)
+            stall_count = _count_stall(ledger, mission_id)
 
             if stall_count >= stall_threshold * 2:
                 # Too many stalls — give up
@@ -550,7 +550,7 @@ def _build_retry_prompt(
     return "\n".join(lines)
 
 
-def _count_stall(ledger: Ledger, mission_id: str, threshold: int) -> int:
+def _count_stall(ledger: Ledger, mission_id: str) -> int:
     """Count consecutive failed attempts from the end.
 
     Counts how many consecutive attempts have gate_passed=False.

--- a/src/automission/models.py
+++ b/src/automission/models.py
@@ -138,6 +138,12 @@ class VerificationResult:
 
     @property
     def mission_passed(self) -> bool:
+        """True when gate passes AND all groups are marked complete by Critic.
+
+        Returns False when group_statuses is empty (e.g. Critic LLM failure),
+        even if the gate passed. This is intentional: a transient Critic failure
+        causes a retry rather than incorrectly completing the mission.
+        """
         return (
             self.harness.passed
             and bool(self.critic.group_statuses)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -223,9 +223,9 @@ class TestAttempts:
         assert mission["total_cost"] == 0.50
         assert mission["total_attempts"] == 1
 
-    def test_get_best_attempt(self, ledger):
+    def test_get_best_attempt_returns_most_recent_passing(self, ledger):
         ledger.create_mission(mission_id="m1", goal="test", backend="claude")
-        # Attempt 1: score 0.3
+        # Attempt 1: failed
         ledger.record_attempt(
             attempt_id="a1",
             mission_id="m1",
@@ -239,27 +239,27 @@ class TestAttempts:
             token_output=2000,
             changed_files=[],
             verification_passed=False,
-            verification_result='{"contract_passed": false, "mission_passed": false, "gate_source": "script", "score": 0.3, "suggestion": ""}',
+            verification_result="{}",
             commit_hash="aaa",
         )
-        # Attempt 2: score 0.7
+        # Attempt 2: passed
         ledger.record_attempt(
             attempt_id="a2",
             mission_id="m1",
             agent_id="agent-1",
             attempt_number=2,
             status="completed",
-            exit_code=1,
+            exit_code=0,
             duration_s=60.0,
             cost_usd=0.20,
             token_input=3000,
             token_output=2000,
             changed_files=[],
-            verification_passed=False,
-            verification_result='{"contract_passed": false, "mission_passed": false, "gate_source": "script", "score": 0.7, "suggestion": ""}',
+            verification_passed=True,
+            verification_result="{}",
             commit_hash="bbb",
         )
-        # Attempt 3: score 0.5
+        # Attempt 3: failed again
         ledger.record_attempt(
             attempt_id="a3",
             mission_id="m1",
@@ -273,12 +273,32 @@ class TestAttempts:
             token_output=2000,
             changed_files=[],
             verification_passed=False,
-            verification_result='{"contract_passed": false, "mission_passed": false, "gate_source": "script", "score": 0.5, "suggestion": ""}',
+            verification_result="{}",
             commit_hash="ccc",
         )
         best = ledger.get_best_attempt("m1")
         assert best is not None
         assert best["attempt_id"] == "a2"
+
+    def test_get_best_attempt_no_passing(self, ledger):
+        ledger.create_mission(mission_id="m1", goal="test", backend="claude")
+        ledger.record_attempt(
+            attempt_id="a1",
+            mission_id="m1",
+            agent_id="agent-1",
+            attempt_number=1,
+            status="completed",
+            exit_code=1,
+            duration_s=60.0,
+            cost_usd=0.20,
+            token_input=3000,
+            token_output=2000,
+            changed_files=[],
+            verification_passed=False,
+            verification_result="{}",
+            commit_hash="aaa",
+        )
+        assert ledger.get_best_attempt("m1") is None
 
     def test_get_best_attempt_empty(self, ledger):
         ledger.create_mission(mission_id="m1", goal="test", backend="claude")


### PR DESCRIPTION
## Summary

- Fix `get_best_attempt()` to use `verification_passed` column instead of removed `score` field (was silently disabling rollback for new-format data)
- Remove unused `threshold` parameter from `_count_stall()`
- Document `mission_passed` intentional behavior when Critic fails (returns False to trigger retry)

## Test plan

- [x] 423 tests pass
- [x] `test_get_best_attempt` rewritten to test actual behavior (most recent passing attempt)
- [x] Added `test_get_best_attempt_no_passing` for edge case

🤖 Generated with [Claude Code](https://claude.com/claude-code)