### PR TITLE
Fix legacy JSON fixtures and silent catches from #42 review

### DIFF
--- a/src/automission/cli.py
+++ b/src/automission/cli.py
@@ -942,8 +942,8 @@ def _render_attempt_log(
             ][:3]
             if failed_groups:
                 header += f" \u2014 focus: {', '.join(failed_groups)}"
-        except (json.JSONDecodeError, KeyError):
-            pass
+        except (json.JSONDecodeError, KeyError) as e:
+            logger.debug("Could not parse prev verification result: %s", e)
     click.echo(header)
 
     # Changed files
@@ -966,8 +966,8 @@ def _render_attempt_log(
             _render_criteria(criteria_data, verbose=verbose)
             if verbose and vr.critic.root_cause:
                 click.echo(f"    root cause: {vr.critic.root_cause}")
-        except (json.JSONDecodeError, KeyError):
-            pass
+        except (json.JSONDecodeError, KeyError) as e:
+            logger.debug("Could not parse verification result: %s", e)
 
 
 def _render_event(event: dict) -> None:

--- a/src/automission/loop.py
+++ b/src/automission/loop.py
@@ -628,8 +628,8 @@ def _load_last_verification(
         return None
     try:
         return VerificationResult.from_json(vr_raw)
-    except (json.JSONDecodeError, KeyError):
-        logger.warning("Could not parse last verification result for resume")
+    except (json.JSONDecodeError, KeyError) as e:
+        logger.warning("Could not parse last verification result for resume: %s", e)
         return None
 
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -147,7 +147,7 @@ class TestAttempts:
             token_output=3000,
             changed_files=["src/calc.py"],
             verification_passed=True,
-            verification_result='{"contract_passed": true}',
+            verification_result='{"harness": {"passed": true, "exit_code": 0}, "critic": {"summary": "ok", "group_statuses": {}}}',
             commit_hash="abc123",
         )
 
@@ -173,7 +173,7 @@ class TestAttempts:
             token_output=2000,
             changed_files=[],
             verification_passed=False,
-            verification_result="{}",
+            verification_result='{"harness": {"passed": false, "exit_code": 1}, "critic": {"summary": "", "group_statuses": {}}}',
             commit_hash="def456",
         )
         ledger.record_attempt(
@@ -189,7 +189,7 @@ class TestAttempts:
             token_output=2500,
             changed_files=["calc.py"],
             verification_passed=True,
-            verification_result="{}",
+            verification_result='{"harness": {"passed": false, "exit_code": 1}, "critic": {"summary": "", "group_statuses": {}}}',
             commit_hash="ghi789",
         )
 
@@ -216,7 +216,7 @@ class TestAttempts:
             token_output=2000,
             changed_files=[],
             verification_passed=True,
-            verification_result="{}",
+            verification_result='{"harness": {"passed": false, "exit_code": 1}, "critic": {"summary": "", "group_statuses": {}}}',
             commit_hash="abc",
         )
         mission = ledger.get_mission("m1")
@@ -239,7 +239,7 @@ class TestAttempts:
             token_output=2000,
             changed_files=[],
             verification_passed=False,
-            verification_result="{}",
+            verification_result='{"harness": {"passed": false, "exit_code": 1}, "critic": {"summary": "", "group_statuses": {}}}',
             commit_hash="aaa",
         )
         # Attempt 2: passed
@@ -256,7 +256,7 @@ class TestAttempts:
             token_output=2000,
             changed_files=[],
             verification_passed=True,
-            verification_result="{}",
+            verification_result='{"harness": {"passed": false, "exit_code": 1}, "critic": {"summary": "", "group_statuses": {}}}',
             commit_hash="bbb",
         )
         # Attempt 3: failed again
@@ -273,7 +273,7 @@ class TestAttempts:
             token_output=2000,
             changed_files=[],
             verification_passed=False,
-            verification_result="{}",
+            verification_result='{"harness": {"passed": false, "exit_code": 1}, "critic": {"summary": "", "group_statuses": {}}}',
             commit_hash="ccc",
         )
         best = ledger.get_best_attempt("m1")
@@ -295,7 +295,7 @@ class TestAttempts:
             token_output=2000,
             changed_files=[],
             verification_passed=False,
-            verification_result="{}",
+            verification_result='{"harness": {"passed": false, "exit_code": 1}, "critic": {"summary": "", "group_statuses": {}}}',
             commit_hash="aaa",
         )
         assert ledger.get_best_attempt("m1") is None

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -142,7 +142,7 @@ class TestRunExecutor:
                 token_output=50,
                 changed_files=[],
                 verification_passed=True,
-                verification_result="{}",
+                verification_result='{"harness": {"passed": true, "exit_code": 0}, "critic": {"summary": "ok", "group_statuses": {}}}',
                 commit_hash="abc123",
             )
 


### PR DESCRIPTION
## Summary

Post-merge code review of #42 found:
- Test fixtures still using legacy `{"contract_passed": true}` and `"{}"` format — replaced with current `harness+critic` format
- Silent `except` blocks in `loop.py` and `cli.py` missing error details — added logging

## Test plan

- [x] 414 tests pass
- [x] ruff check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)