### PR TITLE
Filter automission metadata from all user-facing output

### DIFF
--- a/src/automission/cli.py
+++ b/src/automission/cli.py
@@ -743,7 +743,7 @@ def _collect_changed_files(ledger: Ledger, mission_id: str, ws: Path) -> list[di
 
     summary = []
     for f in sorted(all_files):
-        if not f:
+        if not f or _is_metadata_file(f):
             continue
         status = "modified" if f in baseline_files else "new"
         summary.append({"path": f, "status": status})
@@ -883,6 +883,7 @@ def _fmt_tokens(total: int) -> str:
 
 def _fmt_changed_files(files: list[str], max_shown: int = 5) -> str:
     """Format changed files list: 'a.py, b.py (+2 files)'."""
+    files = [f for f in files if not _is_metadata_file(f)]
     if not files:
         return ""
     basenames = [Path(f).name for f in files]
@@ -1204,9 +1205,10 @@ def logs(mission_id, last, verbose_logs, follow, json_output):
                         "duration_s": a["duration_s"],
                     }
                     try:
-                        entry["changed_files"] = json.loads(
-                            a.get("changed_files", "[]")
-                        )
+                        raw_files = json.loads(a.get("changed_files", "[]"))
+                        entry["changed_files"] = [
+                            f for f in raw_files if not _is_metadata_file(f)
+                        ]
                     except (json.JSONDecodeError, TypeError):
                         entry["changed_files"] = []
                     if verbose_logs and a.get("verification_result"):
@@ -1433,7 +1435,19 @@ _EXPORT_EXCLUDE = {
     "AUTOMISSION.md",
     "verify.sh",
     "skills",
+    "CLAUDE.md",
+    "AGENTS.md",
+    "GEMINI.md",
+    "worktrees",
+    "events.jsonl",
+    "mission.pid",
 }
+
+
+def _is_metadata_file(path: str) -> bool:
+    """Check if a file path is automission internal metadata."""
+    top_level = path.split("/")[0]
+    return top_level in _EXPORT_EXCLUDE
 
 
 @cli.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1104,6 +1104,60 @@ class TestFmtChangedFiles:
         assert "(8 files)" in result
 
 
+class TestIsMetadataFile:
+    """Tests for _is_metadata_file helper."""
+
+    def test_metadata_top_level_files(self):
+        from automission.cli import _is_metadata_file
+
+        for f in [
+            "CLAUDE.md",
+            "AGENTS.md",
+            "GEMINI.md",
+            "AUTOMISSION.md",
+            "MISSION.md",
+            "ACCEPTANCE.md",
+            "verify.sh",
+            "events.jsonl",
+            "mission.pid",
+            "mission.db",
+        ]:
+            assert _is_metadata_file(f) is True, f
+
+    def test_metadata_nested_paths(self):
+        from automission.cli import _is_metadata_file
+
+        assert _is_metadata_file("worktrees/agent-1/file.py") is True
+        assert _is_metadata_file("skills/my_skill.md") is True
+        assert _is_metadata_file(".git/objects/abc") is True
+
+    def test_user_deliverables(self):
+        from automission.cli import _is_metadata_file
+
+        assert _is_metadata_file("src/main.py") is False
+        assert _is_metadata_file("tests/test_foo.py") is False
+        assert _is_metadata_file(".github/workflows/ci.yml") is False
+        assert _is_metadata_file("calculator.py") is False
+
+
+class TestFmtChangedFilesFiltering:
+    """Tests for metadata filtering in _fmt_changed_files."""
+
+    def test_metadata_files_filtered(self):
+        from automission.cli import _fmt_changed_files
+
+        result = _fmt_changed_files(["calculator.py", "CLAUDE.md", "AUTOMISSION.md"])
+        assert "calculator.py" in result
+        assert "CLAUDE.md" not in result
+        assert "AUTOMISSION.md" not in result
+
+    def test_all_metadata_returns_empty(self):
+        from automission.cli import _fmt_changed_files
+
+        result = _fmt_changed_files(["CLAUDE.md", "AUTOMISSION.md", "verify.sh"])
+        assert result == ""
+
+
 class TestRenderCriteria:
     """Tests for _render_criteria helper."""
 


### PR DESCRIPTION
## Summary
- Add missing entries to `_EXPORT_EXCLUDE`: `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `worktrees`, `events.jsonl`, `mission.pid`
- Introduce `_is_metadata_file()` helper to centralize the filtering logic
- Apply filtering to all 5 user-facing display paths: completion output, `--json` output, `logs` per-attempt, `logs --json`, and live `attach` event stream
- Add tests for `_is_metadata_file` and metadata filtering in `_fmt_changed_files`

## Test plan
- [x] All 423 existing tests pass
- [x] New tests verify metadata files are correctly identified and filtered
- [x] New tests verify user deliverables are not filtered
- [x] Lint and format checks pass

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)