### PR TITLE
fix: remove verification_surface from planner LLM output and prevent constraint leakage

### DIFF
--- a/src/automission/backend/protocol.py
+++ b/src/automission/backend/protocol.py
@@ -42,10 +42,14 @@ def format_automission_md(stable: StableContext) -> str:
     lines.append("## Rules")
     lines.append(f"- {stable.side_effect_policy}")
     lines.append(
-        "- Do not modify: AUTOMISSION.md, MISSION.md, ACCEPTANCE.md, verify.sh, mission.db"
+        "- Do not modify: AUTOMISSION.md, MISSION.md, ACCEPTANCE.md, mission.db"
     )
     lines.append("- Read ACCEPTANCE.md before starting work")
     lines.append("- Run verify.sh after making changes")
+    lines.append(
+        "- verify.sh is the test gate. Update it if the default test command "
+        "does not match your implementation (e.g., wrong runner or test directory)."
+    )
     lines.append(
         "- Never hardcode /workspace or any absolute path in code or tests. "
         "Use relative paths (e.g., ./file.py), Path(__file__).parent, or os.getcwd(). "

--- a/src/automission/planner.py
+++ b/src/automission/planner.py
@@ -101,7 +101,6 @@ _PLAN_TOOL = {
             "mission_summary",
             "constraints",
             "groups",
-            "verification_surface",
         ],
         "properties": {
             "mission_summary": {
@@ -145,26 +144,6 @@ _PLAN_TOOL = {
                     },
                 },
             },
-            "verification_surface": {
-                "type": "object",
-                "description": "How to verify the mission. Describes the test runner and targets.",
-                "required": ["runner", "targets"],
-                "properties": {
-                    "runner": {
-                        "type": "string",
-                        "description": "Test runner command (e.g., 'pytest', 'jest', 'go test', 'bash')",
-                    },
-                    "targets": {
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "description": "Test targets (e.g., ['tests/'], ['test/'], ['./...'])",
-                    },
-                    "options": {
-                        "type": "string",
-                        "description": "Additional runner options (e.g., '-v --tb=short'). Empty string if none.",
-                    },
-                },
-            },
             "assumptions": {
                 "type": "array",
                 "items": {"type": "string"},
@@ -188,7 +167,10 @@ unless the user explicitly stated them in the goal
 - Each group should have 2-5 criteria
 - group.id must be valid snake_case and must equal the snake_case form of group.name
 - Dependencies form a DAG (no cycles). Groups with no dependencies start immediately.
-- verification_surface describes how to run tests: runner (e.g., "pytest"), targets (e.g., ["tests/"]), and options (e.g., "-v --tb=short")
+- constraints are about the PROJECT DELIVERABLE, not about how you write this plan. \
+Do NOT repeat your own instructions or planning rules as constraints.
+  BAD: "Describe only observable behaviors and outcomes" (this is YOUR instruction, not a project constraint)
+  GOOD: "All API responses must be valid JSON" (this is a real deliverable constraint)
 
 Call the submit_plan tool with your structured plan."""
 
@@ -240,11 +222,11 @@ class Planner:
                     criteria=criteria,
                 )
             )
-        vs_raw = raw.get("verification_surface", {})
+        # Default verification surface (Option B) — Agent can update verify.sh later
         verification_surface = VerificationSurface(
-            runner=vs_raw.get("runner", "echo"),
-            targets=vs_raw.get("targets", ["'no tests configured'"]),
-            options=vs_raw.get("options", ""),
+            runner="pytest",
+            targets=["tests/"],
+            options="",
         )
         return PlanDraft(
             mission_summary=raw.get("mission_summary", ""),

--- a/src/automission/workspace.py
+++ b/src/automission/workspace.py
@@ -153,7 +153,7 @@ def create_mission(
         stable = StableContext(
             goal=goal,
             skills=skill_contents,
-            rules=["Do not modify verify.sh"],
+            rules=[],
         )
         backend.prepare_workspace(workspace_dir, stable)
 

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -199,11 +199,6 @@ VALID_PLAN_INPUT = {
             ],
         },
     ],
-    "verification_surface": {
-        "runner": "pytest",
-        "targets": ["tests/"],
-        "options": "-v",
-    },
     "assumptions": ["Python"],
 }
 
@@ -227,6 +222,7 @@ class TestPlanner:
         assert len(draft.groups) == 2
         assert draft.groups[0].id == "auth_schema"
         assert draft.groups[1].depends_on == ["auth_schema"]
+        # Now uses default Option B runner
         assert draft.verification_surface.runner == "pytest"
 
     def test_plan_passes_model_to_backend(self):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -245,3 +245,24 @@ class TestCreateMission:
         assert (result / "skills" / "manifest.json").exists()
         content = (result / "AUTOMISSION.md").read_text()
         assert "My Skill" in content
+
+    def test_verify_sh_is_not_protected_in_automission_md(self, tmp_path, fixture_dir):
+        ws = tmp_path / "missions" / "test-verify-sh-not-protected"
+        backend = MockBackend()
+        result = create_mission(
+            mission_id="test-verify-sh-not-protected",
+            goal="Build calculator",
+            acceptance_path=fixture_dir / "ACCEPTANCE.md",
+            verify_path=fixture_dir / "verify.sh",
+            backend=backend,
+            workspace_dir=ws,
+        )
+        content = (result / "AUTOMISSION.md").read_text()
+        # verify.sh should NOT be in the "Do not modify" list anymore
+        # But it IS still in the "Run `bash verify.sh`" instruction, which is fine.
+        do_not_modify_line = next(
+            line for line in content.splitlines() if "Do not modify:" in line
+        )
+        assert "verify.sh" not in do_not_modify_line
+        # The extra rule "Do not modify verify.sh" should also be gone
+        assert "Do not modify verify.sh" not in content


### PR DESCRIPTION
## Summary

Closes #45

- **Remove verification_surface from planner LLM schema** — it's an implementation decision (test runner choice) that the planner lacks context to make. The contradictory prompt rules caused the LLM to produce useless `bash ./`, breaking every verify.sh.
- **Use deterministic default** (`pytest tests/`) instead of LLM-generated verification surface
- **Prevent constraint leakage** — add negative guidance + examples so the LLM stops regurgitating its own instructions as project constraints
- **Make verify.sh mutable** — remove from protected files, add agent instruction that it can update verify.sh to match the actual implementation

## Root Cause

The planner prompt had contradictory rules: "don't invent framework choices" vs "specify a test runner". The LLM resolved this by producing `bash ./` — the most generic (and useless) answer. The real issue was that verification_surface is an implementation decision that doesn't belong in the planning phase.

## Test plan

- [x] All 420 unit tests pass
- [x] Lint + format clean
- [x] Verified verify.sh no longer in protected files list
- [x] Verified default verification surface is `pytest tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)