### PR TITLE
Pin Docker image tag to CLI version to prevent version skew

### DIFF
--- a/src/automission/__init__.py
+++ b/src/automission/__init__.py
@@ -1,3 +1,4 @@
 """automission — Multi-agent autonomous mission execution."""
 
 __version__ = "0.2.7"
+DEFAULT_DOCKER_IMAGE = f"ghcr.io/codance-ai/automission:{__version__}"

--- a/src/automission/backend/claude.py
+++ b/src/automission/backend/claude.py
@@ -6,6 +6,7 @@ import json
 import logging
 from pathlib import Path
 
+from automission import DEFAULT_DOCKER_IMAGE
 from automission.models import AttemptResult, AttemptSpec, StableContext, TokenUsage
 from automission.backend.protocol import format_automission_md
 from automission.backend._helpers import write_instruction_pointer, run_docker_attempt
@@ -20,7 +21,7 @@ class ClaudeCodeBackend:
 
     def __init__(
         self,
-        docker_image: str = "ghcr.io/codance-ai/automission:latest",
+        docker_image: str = DEFAULT_DOCKER_IMAGE,
         auth_method: str = "api_key",
         model: str | None = None,
     ):

--- a/src/automission/backend/codex.py
+++ b/src/automission/backend/codex.py
@@ -6,6 +6,7 @@ import json
 import logging
 from pathlib import Path
 
+from automission import DEFAULT_DOCKER_IMAGE
 from automission.config import get_oauth_volumes
 from automission.models import AttemptResult, AttemptSpec, StableContext, TokenUsage
 from automission.backend.protocol import format_automission_md
@@ -21,7 +22,7 @@ class CodexBackend:
 
     def __init__(
         self,
-        docker_image: str = "ghcr.io/codance-ai/automission:latest",
+        docker_image: str = DEFAULT_DOCKER_IMAGE,
         auth_method: str = "api_key",
         model: str | None = None,
     ):

--- a/src/automission/backend/gemini.py
+++ b/src/automission/backend/gemini.py
@@ -6,6 +6,7 @@ import json
 import logging
 from pathlib import Path
 
+from automission import DEFAULT_DOCKER_IMAGE
 from automission.config import get_oauth_volumes
 from automission.models import AttemptResult, AttemptSpec, StableContext, TokenUsage
 from automission.backend.protocol import format_automission_md
@@ -21,7 +22,7 @@ class GeminiBackend:
 
     def __init__(
         self,
-        docker_image: str = "ghcr.io/codance-ai/automission:latest",
+        docker_image: str = DEFAULT_DOCKER_IMAGE,
         auth_method: str = "api_key",
         model: str | None = None,
     ):

--- a/src/automission/cli.py
+++ b/src/automission/cli.py
@@ -16,7 +16,7 @@ import click
 import questionary
 from questionary import Style
 
-from automission import __version__
+from automission import DEFAULT_DOCKER_IMAGE, __version__
 from automission.config import (
     CONFIG_PATH,
     _KEY_MAP,
@@ -219,7 +219,7 @@ def init(force: bool) -> None:
 
     if docker_ok:
         cfg = load_config()
-        image = cfg.get("docker", "image", "ghcr.io/codance-ai/automission:latest")
+        image = cfg.get("docker", "image", DEFAULT_DOCKER_IMAGE)
         result = subprocess.run(
             ["docker", "image", "inspect", image],
             capture_output=True,
@@ -344,7 +344,7 @@ def _run_oauth_login(backend: str) -> None:
 @click.option("--model", default="claude-sonnet-4-6", help="Model for agent execution")
 @click.option(
     "--docker-image",
-    default="ghcr.io/codance-ai/automission:latest",
+    default=DEFAULT_DOCKER_IMAGE,
     help="Docker image for agent",
 )
 @click.option(
@@ -752,7 +752,7 @@ def _collect_changed_files(ledger: Ledger, mission_id: str, ws: Path) -> list[di
 
 def _create_backend(
     name: str,
-    docker_image: str = "ghcr.io/codance-ai/automission:latest",
+    docker_image: str = DEFAULT_DOCKER_IMAGE,
     auth_method: str = "api_key",
     model: str | None = None,
 ):
@@ -789,7 +789,7 @@ def _create_mission_workspace(
     timeout: int,
     backend_name: str,
     model: str = "claude-sonnet-4-6",
-    docker_image: str = "ghcr.io/codance-ai/automission:latest",
+    docker_image: str = DEFAULT_DOCKER_IMAGE,
     init_files_dir: Path | None = None,
     workspace_dir: Path | None = None,
     acceptance_content: str | None = None,

--- a/src/automission/config.py
+++ b/src/automission/config.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from automission import DEFAULT_DOCKER_IMAGE
 from automission.docker import CONTAINER_HOME
 
 logger = logging.getLogger(__name__)
@@ -94,7 +95,7 @@ model = "{vm}"
 auth = "api_key"
 
 [docker]
-image = "ghcr.io/codance-ai/automission:latest"
+image = "{DEFAULT_DOCKER_IMAGE}"
 """
 
 

--- a/src/automission/db.py
+++ b/src/automission/db.py
@@ -7,6 +7,7 @@ import logging
 import sqlite3
 from pathlib import Path
 
+from automission import DEFAULT_DOCKER_IMAGE
 from automission.models import AcceptanceGroup, Criterion
 
 logger = logging.getLogger(__name__)
@@ -49,7 +50,7 @@ class Ledger:
                 max_iterations INTEGER NOT NULL DEFAULT 20,
                 max_cost REAL NOT NULL DEFAULT 10.0,
                 timeout INTEGER NOT NULL DEFAULT 3600,
-                docker_image TEXT NOT NULL DEFAULT 'ghcr.io/codance-ai/automission:latest',
+                docker_image TEXT NOT NULL,
                 total_cost REAL NOT NULL DEFAULT 0.0,
                 total_attempts INTEGER NOT NULL DEFAULT 0,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -143,7 +144,7 @@ class Ledger:
         max_iterations: int = 20,
         max_cost: float = 10.0,
         timeout: int = 3600,
-        docker_image: str = "ghcr.io/codance-ai/automission:latest",
+        docker_image: str = DEFAULT_DOCKER_IMAGE,
     ) -> None:
         self.conn.execute(
             """INSERT INTO missions (id, goal, backend, model, backend_auth,

--- a/src/automission/executor.py
+++ b/src/automission/executor.py
@@ -19,6 +19,7 @@ import uuid
 from pathlib import Path
 from typing import Callable
 
+from automission import DEFAULT_DOCKER_IMAGE
 from automission.db import Ledger
 from automission.events import EventWriter
 from automission.models import MissionOutcome
@@ -120,7 +121,7 @@ def _execute_mission(
     verifier_backend_name = mission.get("verifier_backend", "claude")
     verifier_model = mission.get("verifier_model", "claude-sonnet-4-6")
     verifier_auth = mission.get("verifier_auth", "api_key")
-    docker_image = mission.get("docker_image", "ghcr.io/codance-ai/automission:latest")
+    docker_image = mission.get("docker_image", DEFAULT_DOCKER_IMAGE)
     agents = mission.get("agents", 1)
     max_iterations = mission.get("max_iterations", 20)
     max_cost = mission.get("max_cost", 10.0)

--- a/src/automission/harness.py
+++ b/src/automission/harness.py
@@ -9,6 +9,7 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+from automission import DEFAULT_DOCKER_IMAGE
 from automission.docker import build_docker_cmd
 from automission.models import HarnessResult, VerificationSurface
 
@@ -18,7 +19,7 @@ logger = logging.getLogger(__name__)
 def run_verify_sh(
     workdir: Path,
     script_path: Path,
-    docker_image: str = "ghcr.io/codance-ai/automission:latest",
+    docker_image: str = DEFAULT_DOCKER_IMAGE,
 ) -> dict[str, Any]:
     """Run verify.sh and return structured gate result.
 
@@ -100,7 +101,7 @@ def run_verify_sh(
 class Harness:
     """Deterministic test execution — runs verify.sh, returns structured result."""
 
-    def __init__(self, docker_image: str = "ghcr.io/codance-ai/automission:latest"):
+    def __init__(self, docker_image: str = DEFAULT_DOCKER_IMAGE):
         self.docker_image = docker_image
 
     def run(self, workdir: Path, verify_sh: Path | None) -> HarnessResult:

--- a/src/automission/structured_output/claude.py
+++ b/src/automission/structured_output/claude.py
@@ -6,6 +6,7 @@ import json
 import logging
 import subprocess
 
+from automission import DEFAULT_DOCKER_IMAGE
 from automission.docker import build_docker_cmd
 from automission.structured_output._errors import (
     CLIResponseError,
@@ -19,7 +20,7 @@ logger = logging.getLogger(__name__)
 class ClaudeStructuredOutput:
     """Structured output via `claude -p --json-schema`."""
 
-    def __init__(self, docker_image: str = "ghcr.io/codance-ai/automission:latest"):
+    def __init__(self, docker_image: str = DEFAULT_DOCKER_IMAGE):
         self.docker_image = docker_image
 
     def query(

--- a/src/automission/structured_output/codex.py
+++ b/src/automission/structured_output/codex.py
@@ -8,6 +8,7 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+from automission import DEFAULT_DOCKER_IMAGE
 from automission.docker import build_docker_cmd
 from automission.structured_output._errors import (
     CLIResponseError,
@@ -54,7 +55,7 @@ class CodexStructuredOutput:
 
     def __init__(
         self,
-        docker_image: str = "ghcr.io/codance-ai/automission:latest",
+        docker_image: str = DEFAULT_DOCKER_IMAGE,
         auth_method: str = "api_key",
     ):
         self.docker_image = docker_image

--- a/src/automission/structured_output/factory.py
+++ b/src/automission/structured_output/factory.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+from automission import DEFAULT_DOCKER_IMAGE
 from automission.structured_output.protocol import StructuredOutputBackend
 
 
 def create_structured_backend(
     name: str,
-    docker_image: str = "ghcr.io/codance-ai/automission:latest",
+    docker_image: str = DEFAULT_DOCKER_IMAGE,
     auth_method: str = "api_key",
 ) -> StructuredOutputBackend:
     """Create a structured output backend by name.

--- a/src/automission/structured_output/gemini.py
+++ b/src/automission/structured_output/gemini.py
@@ -6,6 +6,7 @@ import json
 import logging
 import subprocess
 
+from automission import DEFAULT_DOCKER_IMAGE
 from automission.docker import build_docker_cmd
 from automission.structured_output._errors import (
     CLIResponseError,
@@ -21,7 +22,7 @@ class GeminiStructuredOutput:
 
     def __init__(
         self,
-        docker_image: str = "ghcr.io/codance-ai/automission:latest",
+        docker_image: str = DEFAULT_DOCKER_IMAGE,
         auth_method: str = "api_key",
     ):
         self.docker_image = docker_image

--- a/src/automission/workspace.py
+++ b/src/automission/workspace.py
@@ -8,6 +8,7 @@ import subprocess
 import uuid
 from pathlib import Path
 
+from automission import DEFAULT_DOCKER_IMAGE
 from automission.acceptance import parse_acceptance_md
 from automission.backend.protocol import AgentBackend
 from automission.db import Ledger
@@ -50,7 +51,7 @@ def create_mission(
     max_cost: float = 10.0,
     timeout: int = 3600,
     backend_name: str = "claude",
-    docker_image: str = "ghcr.io/codance-ai/automission:latest",
+    docker_image: str = DEFAULT_DOCKER_IMAGE,
     model: str = "claude-sonnet-4-6",
     agent_auth: str = "api_key",
     verifier_backend_name: str = "claude",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -186,6 +186,7 @@ class TestRunModelFlag:
                     "automission.config", fromlist=["AutomissionConfig"]
                 ).AutomissionConfig(),
             ),
+            patch("automission.docker.ensure_docker"),
         ):
             result = runner.invoke(
                 cli,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
+from automission import DEFAULT_DOCKER_IMAGE
 from automission.config import (
     AutomissionConfig,
     _KEY_MAP,
@@ -201,7 +202,7 @@ class TestGenerateDefaultConfig:
         assert data["defaults"]["max_cost"] == 10.0
         assert data["defaults"]["timeout"] == 3600
         assert data["defaults"]["auth"] == "api_key"
-        assert data["docker"]["image"] == "ghcr.io/codance-ai/automission:latest"
+        assert data["docker"]["image"] == DEFAULT_DOCKER_IMAGE
         assert data["planner"]["backend"] == "claude"
         assert data["planner"]["auth"] == "api_key"
         assert data["verifier"]["backend"] == "claude"

--- a/tests/test_e2e_real.py
+++ b/tests/test_e2e_real.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 import pytest
 
+from automission import DEFAULT_DOCKER_IMAGE
 from automission.db import Ledger
 from automission.loop import run_loop
 from automission.orchestrator import run_multi_agent
@@ -45,7 +46,7 @@ def _docker_available() -> bool:
 
 
 DOCKER_OK = _docker_available()
-DOCKER_IMAGE = "ghcr.io/codance-ai/automission:latest"
+DOCKER_IMAGE = DEFAULT_DOCKER_IMAGE
 
 # Auth detection: API key only (OAuth needs browser, unusable in Docker/CI)
 # Note: Codex CLI reads CODEX_API_KEY, not OPENAI_API_KEY (see #46).


### PR DESCRIPTION
## Summary

- Define `DEFAULT_DOCKER_IMAGE` constant in `__init__.py` derived from `__version__`, replacing 15+ hardcoded `:latest` strings across the codebase
- CLI v0.2.7 now defaults to `ghcr.io/codance-ai/automission:0.2.7` instead of `:latest`
- `ensure_docker()` auto-pulls the correct versioned image if not present locally — no version skew possible
- Users who explicitly set `docker_image` via CLI flag or config.toml are not affected

**Root cause**: `:latest` is a mutable tag. `ensure_docker()` skips pull when a local image exists, so a cached stale `:latest` caused silent version skew after CLI upgrade. Versioned tags are immutable, making the existing "check local → pull if missing" logic correct by construction.

Closes #49

## Test plan

- [x] All 423 unit tests pass
- [x] Lint (ruff check + format) clean
- [x] Verified `ghcr.io/codance-ai/automission:0.2.7` exists on registry
- [x] Code review: no CRITICAL/HIGH findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)