### PR TITLE
fix: replace misleading verification checkmarks with narrative display

### DIFF
--- a/src/automission/cli.py
+++ b/src/automission/cli.py
@@ -896,25 +896,25 @@ def _fmt_changed_files(files: list[str], max_shown: int = 5) -> str:
 def _render_criteria(
     event_or_vr: dict, *, indent: str = "    ", verbose: bool = False
 ) -> None:
-    """Render verification summary from event or verification result dict."""
+    """Render verification narrative: summary + next actions.
+
+    Shows what happened and what remains, rather than per-group pass/fail
+    judgments (which depend on unreliable LLM advisory analysis).
+    """
     summary = event_or_vr.get("summary", "")
     if summary:
         click.echo(f"{indent}{summary}")
 
-    group_analysis = event_or_vr.get("group_analysis", {})
-    if group_analysis:
-        for gid, completed in group_analysis.items():
-            symbol = (
-                click.style("\u2713", fg="green")
-                if completed
-                else click.style("\u2717", fg="red")
-            )
-            click.echo(f"{indent}{symbol} {gid}")
-
     next_actions = event_or_vr.get("next_actions", [])
-    if verbose and next_actions:
-        for action in next_actions:
+    if next_actions:
+        shown = next_actions if verbose else next_actions[:3]
+        for action in shown:
             click.echo(f"{indent}  \u2192 {action}")
+
+    if verbose:
+        root_cause = event_or_vr.get("root_cause", "")
+        if root_cause:
+            click.echo(f"{indent}  root cause: {root_cause}")
 
 
 def _render_attempt_log(
@@ -955,18 +955,16 @@ def _render_attempt_log(
     if changed:
         click.echo(f"    changed: {_fmt_changed_files(changed)}")
 
-    # Criteria breakdown
+    # Verification narrative
     if attempt.get("verification_result"):
         try:
             vr = VerificationResult.from_json(attempt["verification_result"])
             criteria_data = {
                 "summary": vr.critic.summary,
-                "group_analysis": vr.group_analysis,
                 "next_actions": vr.critic.next_actions,
+                "root_cause": vr.critic.root_cause,
             }
             _render_criteria(criteria_data, verbose=verbose)
-            if verbose and vr.critic.root_cause:
-                click.echo(f"    root cause: {vr.critic.root_cause}")
         except (json.JSONDecodeError, KeyError) as e:
             logger.debug("Could not parse verification result: %s", e)
 
@@ -999,9 +997,6 @@ def _render_event(event: dict) -> None:
         label = "PASS" if passed else "FAIL"
         click.echo(f"  verify: {click.style(label, fg=color)}")
         _render_criteria(event)
-        summary = event.get("summary")
-        if summary:
-            click.echo(f"    {summary}")
     elif etype == "group_start":
         name = event.get("group_name", event.get("group_id", "?"))
         click.echo(f"\nWorking on: {name}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1166,31 +1166,66 @@ class TestFmtChangedFilesFiltering:
 class TestRenderCriteria:
     """Tests for _render_criteria helper."""
 
-    def test_summary_and_group_analysis(self, capsys):
+    def test_summary_and_next_actions(self, capsys):
         from automission.cli import _render_criteria
 
         event = {
-            "summary": "Tests failing, 1/2 groups pass.",
-            "group_analysis": {"basic_arithmetic": True, "input_handling": False},
-            "next_actions": ["Fix input handling"],
+            "summary": "Tests failing, input handling incomplete.",
+            "next_actions": ["Fix input handling", "Add validation"],
         }
         _render_criteria(event)
         out = capsys.readouterr().out
         assert "Tests failing" in out
-        assert "basic_arithmetic" in out
-        assert "input_handling" in out
+        assert "Fix input handling" in out
+        assert "Add validation" in out
 
-    def test_verbose_next_actions(self, capsys):
+    def test_next_actions_limited_to_3_by_default(self, capsys):
+        from automission.cli import _render_criteria
+
+        event = {
+            "summary": "Multiple issues.",
+            "next_actions": ["Action 1", "Action 2", "Action 3", "Action 4"],
+        }
+        _render_criteria(event)
+        out = capsys.readouterr().out
+        assert "Action 1" in out
+        assert "Action 3" in out
+        assert "Action 4" not in out
+
+    def test_verbose_shows_all_actions_and_root_cause(self, capsys):
         from automission.cli import _render_criteria
 
         event = {
             "summary": "Division by zero not handled.",
-            "group_analysis": {"error_handling": False},
-            "next_actions": ["Handle division by zero case"],
+            "next_actions": [
+                "Handle division by zero case",
+                "Action 2",
+                "Action 3",
+                "Action 4",
+            ],
+            "root_cause": "Missing guard in evaluate()",
         }
         _render_criteria(event, verbose=True)
         out = capsys.readouterr().out
         assert "Handle division by zero case" in out
+        assert "Action 4" in out
+        assert "Missing guard in evaluate()" in out
+
+    def test_no_group_analysis_displayed(self, capsys):
+        """group_analysis should not appear in display (advisory data kept internal)."""
+        from automission.cli import _render_criteria
+
+        event = {
+            "summary": "Tests pass.",
+            "group_analysis": {"basic_arithmetic": True, "input_handling": False},
+            "next_actions": [],
+        }
+        _render_criteria(event)
+        out = capsys.readouterr().out
+        assert "basic_arithmetic" not in out
+        assert "input_handling" not in out
+        assert "\u2713" not in out  # no checkmark
+        assert "\u2717" not in out  # no cross
 
     def test_empty_event(self, capsys):
         from automission.cli import _render_criteria
@@ -1258,7 +1293,7 @@ class TestRenderEventRichOutput:
         out = capsys.readouterr().out
         assert "changed" not in out
 
-    def test_verification_with_summary_and_groups(self, capsys):
+    def test_verification_fail_with_narrative(self, capsys):
         from automission.cli import _render_event
 
         event = {
@@ -1271,11 +1306,13 @@ class TestRenderEventRichOutput:
         _render_event(event)
         out = capsys.readouterr().out
         assert "FAIL" in out
-        assert "input_handling" in out
-        assert "basic_arithmetic" in out
         assert "Tests failing" in out
+        assert "Fix subprocess call" in out
+        # group_analysis should not appear as checkmarks
+        assert "\u2713" not in out
+        assert "\u2717" not in out
 
-    def test_verification_pass(self, capsys):
+    def test_verification_pass_with_narrative(self, capsys):
         from automission.cli import _render_event
 
         event = {
@@ -1289,3 +1326,18 @@ class TestRenderEventRichOutput:
         out = capsys.readouterr().out
         assert "PASS" in out
         assert "All tests pass" in out
+
+    def test_verification_no_duplicate_summary(self, capsys):
+        """Summary should appear exactly once (was a bug)."""
+        from automission.cli import _render_event
+
+        event = {
+            "type": "verification",
+            "passed": True,
+            "summary": "Unique summary text.",
+            "group_analysis": {},
+            "next_actions": [],
+        }
+        _render_event(event)
+        out = capsys.readouterr().out
+        assert out.count("Unique summary text.") == 1


### PR DESCRIPTION
## Summary

- Replace per-group ✓/✗ checkmarks (unreliable LLM advisory) with Critic's narrative output (summary + next_actions) in verification display
- Show `next_actions` by default (capped at 3), with all actions + `root_cause` in verbose mode
- Fix duplicate summary bug in live event view (`automission follow`)

### Before
```
  verify: PASS                  ← misleading
    ✓ input_handling
    ✗ expression_evaluation
    ✗ result_output
```

### After
```
  verify: PASS
    Input handling tests pass; expression evaluation not implemented
    → Implement basic arithmetic operations
    → Add result formatting logic
```

Closes #53

## Test plan

- [x] All 426 tests pass
- [x] Lint clean (ruff check + format)
- [x] New tests: narrative display, 3-action cap, verbose mode, no-checkmarks assertion, no-duplicate-summary regression test
- [x] Code review: APPROVE (no blocking issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)